### PR TITLE
tests: add timer test to ensure we don't modify behavior

### DIFF
--- a/test/spootnik/reporter_test.clj
+++ b/test/spootnik/reporter_test.clj
@@ -1,0 +1,15 @@
+(ns spootnik.reporter-test
+  (:require [clojure.test :refer :all]
+            [spootnik.reporter :refer :all]
+            [com.stuartsierra.component :as component]))
+
+(deftest timers-do-not-modify-the-world
+  (let [reporter (component/start (map->Reporter {:metrics {:reporters {:console {:interval 100}}}}))]
+
+    (is (= (time! reporter :one (+ 1 2))
+           (time! nil :one (+ 1 2))))
+
+    (is (= (time! reporter :two (do (Thread/sleep 200) "foo"))
+           (time! nil :two "foo")))
+
+    (component/stop reporter)))


### PR DESCRIPTION
A quick test to ensure we do not mess around with the return value.
We used to in a previous version of the library. This came up while chasing for a totally different bug, but at least we got a test out of it.