### PR TITLE
Extract build-metrics-reporter from build-metrics-reporters

### DIFF
--- a/test/spootnik/reporter_test.clj
+++ b/test/spootnik/reporter_test.clj
@@ -20,7 +20,7 @@
     (let [reporter (component/start (map->Reporter {:sentry {:dsn ":memory:"}
                                                     :metrics {:reporters {:console {:interval 100}}}}))]
 
-      (.capture! reporter {:message "A simple test event"})
+      (.capture! ^spootnik.reporter.SentrySink reporter {:message "A simple test event"})
       (is (= "A simple test event" (:message (first @http-requests-payload-stub))))
 
       (component/stop reporter))))


### PR DESCRIPTION
This PR proposes the extraction of the case statement into a multimethod in order to:
- Simplify `build-metrics-reporters`
- Make the logic pluggable
