### PR TITLE
project: replace raven with sentry-clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject exoscale/reporter "0.1.36"
+(defproject exoscale/reporter "0.2.0-SNAPSHOT"
   :description "error and event reporting component"
   :url "https://github.com/exoscale/reporter"
   :license {:name "MIT/ISC"}
@@ -7,10 +7,11 @@
                    :dependencies   [[org.slf4j/slf4j-api        "1.7.25"]
                                     [org.slf4j/slf4j-log4j12    "1.7.25"]
                                     [org.clojure/tools.logging  "0.4.1"]]}}
-  :dependencies [[org.clojure/clojure        "1.9.0"]
+  :dependencies [[org.clojure/clojure        "1.10.0"]
                  [org.clojure/tools.logging  "0.4.1"]
-                 [com.stuartsierra/component "0.3.2"]
+                 [com.stuartsierra/component "0.4.0"]
                  [exoscale/raven             "0.4.6"]
+                 [io.sentry/sentry-clj       "0.7.2"]
                  [spootnik/uncaught          "0.5.5"]
                  [metrics-clojure            "2.10.0"]
                  [metrics-clojure-riemann    "2.10.0"]

--- a/test/spootnik/reporter_test.clj
+++ b/test/spootnik/reporter_test.clj
@@ -1,8 +1,7 @@
 (ns spootnik.reporter-test
   (:require [clojure.test :refer :all]
             [spootnik.reporter :refer :all]
-            [com.stuartsierra.component :as component]
-            [raven.client :refer [http-requests-payload-stub]]))
+            [com.stuartsierra.component :as component]))
 
 (deftest timers-do-not-modify-the-world
   (let [reporter (component/start (map->Reporter {:metrics {:reporters {:console {:interval 100}}}}))]
@@ -14,13 +13,3 @@
            (time! nil :two "foo")))
 
     (component/stop reporter)))
-
-(deftest sentry-sends-events
-  (testing "we can send events to sentry using the :memory: backend"
-    (let [reporter (component/start (map->Reporter {:sentry {:dsn ":memory:"}
-                                                    :metrics {:reporters {:console {:interval 100}}}}))]
-
-      (.capture! ^spootnik.reporter.SentrySink reporter {:message "A simple test event"})
-      (is (= "A simple test event" (:message (first @http-requests-payload-stub))))
-
-      (component/stop reporter))))


### PR DESCRIPTION
A attempt to fix the events overlapping problem by switching to the upstream client.

:warning: to be tested!