### PR TITLE
reporter: stop wants a context

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject exoscale/reporter "0.1.37"
+(defproject exoscale/reporter "0.1.38-SNAPSHOT"
   :description "error and event reporting component"
   :url "https://github.com/exoscale/reporter"
   :license {:name "MIT/ISC"}

--- a/src/spootnik/reporter.clj
+++ b/src/spootnik/reporter.clj
@@ -43,7 +43,7 @@
   (update! [this alias v])
   (time-fn! [this alias f])
   (start! [this alias])
-  (stop! [this alias]))
+  (stop! [this ctx]))
 
 (def config->protocol
   (comp keyword
@@ -282,9 +282,9 @@
   (start! [this alias]
     (when registry
       (tmr/start (tmr/timer registry (->alias alias)))))
-  (stop! [this alias]
+  (stop! [this ctx]
     (when registry
-      (tmr/stop (tmr/timer registry (->alias alias)))))
+      (tmr/stop (tmr/timer registry ctx))))
   SentrySink
   (capture! [this e]
     (capture! this e {}))
@@ -324,7 +324,7 @@
   (update! [this alias v])
   (time-fn! [this alias f] (f))
   (start! [this alias])
-  (stop! [this alias])
+  (stop! [this ctx])
   SentrySink
   (capture! ([this e]) ([this e tags]))
   RiemannSink


### PR DESCRIPTION
> :cause class com.codahale.metrics.Timer$Context cannot be cast to class clojure.lang.Named (com.codahale.metrics.Timer$Context and clojure.lang.Named are in unnamed module of loader 'app')
