### PR TITLE
fix missing redef on reporter

### DIFF
--- a/src/spootnik/reporter.clj
+++ b/src/spootnik/reporter.clj
@@ -4,7 +4,7 @@
             [raven.client :as raven]
             [spootnik.reporter.impl :as rptr]))
 
-(def reporter
+(def ^:redef reporter
   "The main reporter instance"
   nil)
 


### PR DESCRIPTION
> For parts of your own app, you may wish to only enable direct linking when you build and deploy for production, rather than using it when you developing at the REPL. Or you may need to mark parts of your app with ^:redef if you want to always allow redefinition or ^:dynamic for dynamic vars.

