### PR TITLE
fix(deps): Explicitly add javax dependencies for java11

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,4 +23,5 @@
                  [io.prometheus/simpleclient            "0.8.0"]
                  [io.prometheus/simpleclient_common     "0.8.0"]
                  [io.prometheus/simpleclient_hotspot    "0.8.0"]
-                 [io.prometheus/simpleclient_dropwizard "0.8.0"]])
+                 [io.prometheus/simpleclient_dropwizard "0.8.0"]
+                 [javax.xml.bind/jaxb-api               "2.4.0-b180830.0359"]])


### PR DESCRIPTION
Java11 removed javax APIs. The riemann TLS driver relies on these to
load certificates.
An explicit dependency needs to be added that provides/backports these
APIs. See https://stackoverflow.com/questions/52502189/java-11-package-javax-xml-bind-does-not-exist

I have tested this on java8 as well, and this does not seem to cause any
issues there.