### PR TITLE
stop method should always return the stopped component

### DIFF
--- a/src/spootnik/reporter/impl.clj
+++ b/src/spootnik/reporter/impl.clj
@@ -289,29 +289,28 @@
           prometheus (assoc :prometheus {:server   prometheus-server
                                          :registry prometheus-registry})))))
   (stop [this]
-    (if started?
-      (do
-        (when-not prevent-capture?
-          (with-uncaught e
-            (error e "uncaught exception.")))
-        (doseq [r reporters]
-          (c/stop r))
-        (when registry
-          (info "shutting down metric registry")
-          (m/remove-all-metrics registry))
-        (when rclient
-          (try
-            (.close ^RiemannClient rclient)
-            (catch Exception _)))
-        (when prometheus
-          (.close ^java.io.Closeable (:server prometheus))))
-      (assoc this
-             :raven-options nil
-             :reporters nil
-             :registry nil
-             :rclient nil
-             :prometheus nil
-             :started? false)))
+    (when started?
+      (when-not prevent-capture?
+        (with-uncaught e
+          (error e "uncaught exception.")))
+      (doseq [r reporters]
+        (c/stop r))
+      (when registry
+        (info "shutting down metric registry")
+        (m/remove-all-metrics registry))
+      (when rclient
+        (try
+          (.close ^RiemannClient rclient)
+          (catch Exception _)))
+      (when prometheus
+        (.close ^java.io.Closeable (:server prometheus))))
+    (assoc this
+           :raven-options nil
+           :reporters nil
+           :registry nil
+           :rclient nil
+           :prometheus nil
+           :started? false))
   MetricHolder
   (instrument! [this prefix]
     (when registry


### PR DESCRIPTION
Whether or not the `stop` method actually ends up doing anything, it should always return the component in a stopped state. Without this change, it only does so in the case that `started?` is falsey. When it actually closes connections etc, it ends up returning nil. It seems we have several examples of the reporter not being able to shut down cleanly. Not sure if this is the cause but it should probably be fixed anyway.