### PR TITLE
d/chain for capture! function

### DIFF
--- a/src/spootnik/reporter.clj
+++ b/src/spootnik/reporter.clj
@@ -84,11 +84,9 @@
                            (raven/add-exception! error))
                        {:message error})
                      (raven/add-extra! extra)))
-
        (d/catch Throwable
            (fn [e]
              (log/error e "Sentry failure")))
-
        (try
          (catch Throwable e
            (log/error e "Sentry failure"))))))


### PR DESCRIPTION
This PR fixes the `report-error` helper function. There are two changes:

1. The function might take either one or two arguments (in my case, I don't have data to submit).
2. Before, the ordinary `try/catch` form didn't take into account that the `capture!` function returns a deferred value. It means, if there was an HTTP error with Sentry, we'll get the deferred value, so the outer try/catch form would not work. We have already had such issue in Obwald. We `capture!` the message and then terminated the program without dereferencing nor sleeping. That's why we didn't see the messages in Kibana.
