### PR TITLE
  pushgateway: ensure job is a string

### DIFF
--- a/src/spootnik/reporter/impl.clj
+++ b/src/spootnik/reporter/impl.clj
@@ -353,7 +353,7 @@
       this
       (let [prometheus-registry         (CollectorRegistry/defaultRegistry)
             [pgclient pgjob pgregistry pggrouping-keys] (when pushgateway [(build-pushgateway-client pushgateway)
-                                                                           (:job pushgateway)
+                                                                           (name (:job pushgateway))
                                                                            (CollectorRegistry.)
                                                                            (parse-pggrouping-keys (:grouping-keys pushgateway))])
             pgmetrics            (when pushgateway (build-collectors! pgregistry (get-in metrics [:reporters :pushgateway])))
@@ -363,7 +363,7 @@
             prometheus-server    (when prometheus
                                    (let [tls (:tls prometheus)
                                          opts (cond->
-                                               {:port (:port prometheus)}
+                                                {:port (:port prometheus)}
                                                 (some? (:tls prometheus))
                                                 (assoc :ssl-context (server-ssl-context tls))
                                                 (:host prometheus)


### PR DESCRIPTION
The `job` needs to match what is passed to the impl, although the config requires a keyword, the impl requires a string.

- https://github.com/exoscale/reporter/blob/master/src/spootnik/reporter/specs.clj#L39 (keyword)
- https://github.com/exoscale/reporter/blob/master/src/spootnik/reporter/impl.clj#L339 (string)