### PR TITLE
pushgateway: fix authority CA key

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject exoscale/reporter "0.1.59"
+(defproject exoscale/reporter "0.1.59-SNAPSHOT"
   :description "error and event reporting component"
   :url "https://github.com/exoscale/reporter"
   :license {:name "MIT/ISC"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject exoscale/reporter "0.1.60-SNAPSHOT"
+(defproject exoscale/reporter "0.1.59-SNAPSHOT"
   :description "error and event reporting component"
   :url "https://github.com/exoscale/reporter"
   :license {:name "MIT/ISC"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject exoscale/reporter "0.1.59-SNAPSHOT"
+(defproject exoscale/reporter "0.1.59"
   :description "error and event reporting component"
   :url "https://github.com/exoscale/reporter"
   :license {:name "MIT/ISC"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject exoscale/reporter "0.1.59-SNAPSHOT"
+(defproject exoscale/reporter "0.1.60-SNAPSHOT"
   :description "error and event reporting component"
   :url "https://github.com/exoscale/reporter"
   :license {:name "MIT/ISC"}

--- a/src/spootnik/reporter/impl.clj
+++ b/src/spootnik/reporter/impl.clj
@@ -97,7 +97,7 @@
          (.set (SSL/sslContext
                 (:pkey tls)
                 (:cert tls)
-                (:authority tls)))))))
+                (:ca-cert tls)))))))
 
 (defmethod build-client :default
   [_]

--- a/src/spootnik/reporter/specs.clj
+++ b/src/spootnik/reporter/specs.clj
@@ -11,9 +11,8 @@
                    :spootnik.reporter.config/password]))
 (s/def :spootnik.reporter.config/cert string?)
 (s/def :spootnik.reporter.config/ca-cert string?)
-(s/def :spootnik.reporter.config/authority string?)
 (s/def :spootnik.reporter.config/pkey string?)
-(s/def :spootnik.reporter.config/ssl-cert (s/keys :req-un [:spootnik.reporter.config/cert :spootnik.reporter.config/authority :spootnik.reporter.config/pkey]))
+(s/def :spootnik.reporter.config/ssl-cert (s/keys :req-un [:spootnik.reporter.config/cert :spootnik.reporter.config/ca-cert :spootnik.reporter.config/pkey]))
 (s/def :spootnik.reporter.config/ssl (s/or :bundle :spootnik.reporter.config/ssl-bundle :cert :spootnik.reporter.config/ssl-cert))
 
 ;; Generic

--- a/test/spootnik/reporter/specs_test.clj
+++ b/test/spootnik/reporter/specs_test.clj
@@ -19,7 +19,7 @@
                         :tags ["cpu" "graph"]}
 
              :tls {:cert      "/etc/riemann/ssl/cert.pem"
-                   :authority "/etc/riemann/ssl/ca.pem"
+                   :ca-cert   "/etc/riemann/ssl/ca.pem"
                    :pkey      "/etc/riemann/ssl/key.pkcs8"}}
    :metrics {:reporters {:riemann {:interval 10
                                    :opts     {:ttl       20


### PR DESCRIPTION
The authority key in `tls` section must match what the ssl context factory function expects (eg: `ca-cert`), otherwise the ssl context will be built with a nil CA and SSL host validation will fail.

