### PR TITLE
sentry: log exception occuring before manifold.deferred is created

### DIFF
--- a/src/spootnik/reporter/impl.clj
+++ b/src/spootnik/reporter/impl.clj
@@ -489,7 +489,10 @@
     (capture! this e {}))
   (capture! [this e tags]
     (if (:dsn sentry)
-      (-> (raven/capture! raven-options (:dsn sentry) e tags)
+      (-> (try
+            (raven/capture! raven-options (:dsn sentry) e tags)
+            (catch Exception e
+              (d/error-deferred e)))
           (d/chain
            (fn [event-id]
              (error e (str "captured exception as sentry event: " event-id))))


### PR DESCRIPTION
We are experiencing a Jackson serialization error while trying to capture an error into Sentry
This error is generated before the `manifold.deferred` representing the HTTP call is created
=> we are now wrapping the `raven/capture!` with a try/catch to log when such an error occurs