### PR TITLE
Migrate to sentry-clj. Getting rid of raven lib.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,14 @@ Reporter provides a [component](https://github.com/stuartsierra/component) in or
 
 ### Changelog
 
+#### 1.0.0
+
+- Migrating from `exoscale/raven` to `io.sentry/sentry-clj`
+- `raven-options` renamed to `sentry-options` within `spootnik.reporter.impl/Reporter` signature
+
 #### 0.2.0
 
-- Allow arbitray values for counter 
+- Allow arbitray values for counter
 
 #### 0.1.60
 

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
  {org.clojure/clojure        "1.9.0"
   org.clojure/tools.logging  "0.4.0"
   com.stuartsierra/component "0.3.2"
-  exoscale/raven             "0.4.2"
+  io.sentry/sentry-clj       "7.4.213"
   spootnik/net               "0.3.3-beta24"
   spootnik/uncaught          "0.5.3"
   metrics-clojure            "2.10.0"

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [org.clojure/clojure                    "1.10.1"]
                  [org.clojure/tools.logging              "1.0.0"]
                  [com.stuartsierra/component             "1.0.0"]
-                 [exoscale/raven                         "0.4.15"]
+                 [io.sentry/sentry-clj                   "7.4.213"]
                  [spootnik/uncaught                      "0.5.5"]
                  [metrics-clojure                        "2.10.0"]
                  [metrics-clojure-riemann                "2.10.0"]

--- a/src/spootnik/reporter.clj
+++ b/src/spootnik/reporter.clj
@@ -1,7 +1,6 @@
 (ns spootnik.reporter
   (:require [com.stuartsierra.component :as c]
             [clojure.tools.logging :as log]
-            [raven.client :as raven]
             [spootnik.reporter.impl :as rptr]
             [manifold.deferred :as d]
             spootnik.reporter.specs))
@@ -80,11 +79,10 @@
 
   ([error extra]
    (log/error error)
-   (-> (capture! (-> (if (instance? Exception error)
-                       (-> {:data (ex-data error)}
-                           (raven/add-exception! error))
-                       {:message error})
-                     (raven/add-extra! extra)))
+   (-> (capture! (if (instance? Exception error)
+                   {:extra extra
+                    :throwable error}
+                   {:message error}))
        (d/catch Throwable
                 (fn [e]
                   (log/error e "Sentry failure")))

--- a/src/spootnik/reporter/impl.clj
+++ b/src/spootnik/reporter/impl.clj
@@ -404,7 +404,7 @@
                                                prometheus-registry)
                                       opts)))]
 
-        (rs/init! (:dsn sentry) sentry)
+        (rs/init! sentry)
 
         (when-not prevent-capture?
           (with-uncaught e
@@ -439,7 +439,7 @@
       (when prometheus
         (.close ^java.io.Closeable (:server prometheus)))
 
-      (rs/close! (:dsn sentry)))
+      (rs/close! sentry))
 
     (assoc this
            :raven-options nil

--- a/src/spootnik/reporter/impl.clj
+++ b/src/spootnik/reporter/impl.clj
@@ -371,9 +371,11 @@
 (defn parse-pggrouping-keys [grouping-keys]
   (into {} (for [[k v] grouping-keys] [(csk/->snake_case_string k) v])))
 
-;; "sentry" is a configuration map sent to sentry.io on initialisation
-;; https://github.com/getsentry/sentry-clj/tree/master?tab=readme-ov-file#additional-initialisation-options
-(defrecord Reporter [rclient raven-options reporters registry sentry metrics riemann prevent-capture? prometheus
+;; Reporter configuration specs:
+;; https://github.com/exoscale/reporter/blob/master/src/spootnik/reporter/specs.clj
+
+(defrecord Reporter [rclient raven-options reporters registry sentry
+                     metrics riemann prevent-capture? prometheus
                      started? pushgateway]
   c/Lifecycle
   (start [this]

--- a/src/spootnik/reporter/sentry.clj
+++ b/src/spootnik/reporter/sentry.clj
@@ -48,29 +48,30 @@
       (or (System/getenv "HOSTNAME")
           (second (swap! cache hostname))))))
 
-(defn- e->sentry-request [e]
-  (let [payload (-> e :extra :payload)]
-    {:url          (-> payload :uri)
-     :method       (-> payload :request-method name clojure.string/upper-case)
-     :query-string (-> payload :query-string)
-     :headers      (-> payload :headers)}))
+(defn- payload->sentry-request [payload]
+  {:url          (-> payload :uri)
+   :method       (-> payload :request-method name clojure.string/upper-case)
+   :query-string (-> payload :query-string)
+   :headers      (-> payload :headers)})
 
 (defn e->sentry-event [e options tags]
-  (let [{:keys [message extra throwable]} e]
+  (let [{:keys [message extra throwable]} e
+        message      (or message (ex-message e))
+        user         (some-> extra :org/uuid str)
+        fingerprints (some-> options :fingerpint seq)
+        request      (some-> extra :payload payload->sentry-request)]
 
-    (if message
-      {:message message}
+    (cond-> {:message message
+             :level :error
+             :platform "java"
+             :server-name  (localhost)}
 
-      {:message      (ex-message e)
-       :request      (e->sentry-request e)
-       :level        :error
-       :platform     "java"
-       :user         {:id (-> e :extra :org/uuid str)}
-       :tags         tags
-       :server-name  (localhost)
-       :fingerprints (some-> options :fingerpint seq)
-       :extra        extra
-       :throwable    throwable})))
+      throwable    (assoc :throwable throwable)
+      extra        (assoc :extra extra)
+      (seq tags)   (assoc :tags tags)
+      user         (assoc :user user)
+      fingerprints (assoc :fingerprints fingerprints)
+      request      (assoc :request request))))
 
 (defn send-event! [dsn options e tags]
   (let [event (e->sentry-event e options tags)]
@@ -79,12 +80,15 @@
             (sentry-io/send-event event)
             (catch Exception e
               (d/error-deferred e)))
+
           (d/chain
            (fn [event-id]
              (error e (str "captured exception as sentry event: " event-id))))
+
           (d/catch (fn [e']
                      (error e "Failed to capture exception" {:tags tags :capture-exception e'})
                      (send-event! dsn options e' tags))))
+
       (swap! http-requests-payload-stub conj event))))
 
 (defn init! [dsn sentry]

--- a/src/spootnik/reporter/sentry.clj
+++ b/src/spootnik/reporter/sentry.clj
@@ -1,0 +1,98 @@
+(ns spootnik.reporter.sentry
+  (:require
+   [sentry-clj.core :as sentry-io]
+   [manifold.deferred  :as d]
+   [clojure.string :as str]
+   [clojure.tools.logging :refer [error]]
+   [clojure.java.shell :as sh]))
+
+(def http-requests-payload-stub
+  "Storage for stubbed http sentry events "
+  (atom nil))
+
+(defn in-memory? [dsn]
+  (or (= dsn ":memory:")
+      (nil? dsn)))
+
+(def hostname-refresh-interval
+  "How often to allow reading /etc/hostname, in seconds."
+  60)
+
+(defn get-hostname
+  "Get the current hostname by shelling out to 'hostname'"
+  []
+  (or
+   (try
+     (let [{:keys [exit out]} (sh/sh "hostname")]
+       (when (= exit 0)
+         (str/trim out)))
+     (catch Exception _))
+   "<unknown>"))
+
+(defn hostname
+  "Fetches the hostname by shelling to 'hostname', whenever the given age
+  is stale enough. If the given age is recent, as defined by
+  hostname-refresh-interval, returns age and val instead."
+  [[age val]]
+  (if (and val (<= (* 1000 hostname-refresh-interval)
+                   (- (System/currentTimeMillis) age)))
+    [age val]
+    [(System/currentTimeMillis) (get-hostname)]))
+
+(let [cache (atom [nil nil])]
+  (defn localhost
+    "Returns the local host name."
+    []
+    (if (re-find #"^Windows" (System/getProperty "os.name"))
+      (or (System/getenv "COMPUTERNAME") "localhost")
+      (or (System/getenv "HOSTNAME")
+          (second (swap! cache hostname))))))
+
+(defn- e->sentry-request [e]
+  (let [payload (-> e :extra :payload)]
+    {:url          (-> payload :uri)
+     :method       (-> payload :request-method name clojure.string/upper-case)
+     :query-string (-> payload :query-string)
+     :headers      (-> payload :headers)}))
+
+(defn e->sentry-event [e options tags]
+  (let [{:keys [message extra throwable]} e]
+
+    (if message
+      {:message message}
+
+      {:message      (ex-message e)
+       :request      (e->sentry-request e)
+       :level        :error
+       :platform     "java"
+       :user         {:id (-> e :extra :org/uuid str)}
+       :tags         tags
+       :server-name  (localhost)
+       :fingerprints (some-> options :fingerpint seq)
+       :extra        extra
+       :throwable    throwable})))
+
+(defn send-event! [dsn options e tags]
+  (let [event (e->sentry-event e options tags)]
+    (if-not (in-memory? dsn)
+      (-> (try
+            (sentry-io/send-event event)
+            (catch Exception e
+              (d/error-deferred e)))
+          (d/chain
+           (fn [event-id]
+             (error e (str "captured exception as sentry event: " event-id))))
+          (d/catch (fn [e']
+                     (error e "Failed to capture exception" {:tags tags :capture-exception e'})
+                     (send-event! dsn options e' tags))))
+      (swap! http-requests-payload-stub conj event))))
+
+(defn init! [dsn sentry]
+  (if-not (in-memory? dsn)
+    (sentry-io/init! (:dsn sentry) sentry)
+    (reset! http-requests-payload-stub [])))
+
+(defn close! [dsn]
+  (if-not (in-memory? dsn)
+    (sentry-io/close!)
+    (reset! http-requests-payload-stub nil)))

--- a/src/spootnik/reporter/sentry.clj
+++ b/src/spootnik/reporter/sentry.clj
@@ -83,7 +83,8 @@
 
           (d/chain
            (fn [event-id]
-             (error e (str "captured exception as sentry event: " event-id))))
+             (error e (str "captured exception as sentry event: " event-id))
+             event-id))
 
           (d/catch (fn [e']
                      (error e "Failed to capture exception" {:tags tags :capture-exception e'})

--- a/src/spootnik/reporter/sentry.clj
+++ b/src/spootnik/reporter/sentry.clj
@@ -92,12 +92,12 @@
 
       (swap! http-requests-payload-stub conj event))))
 
-(defn init! [dsn sentry]
+(defn init! [{:keys [dsn] :as sentry}]
   (if-not (in-memory? dsn)
-    (sentry-io/init! (:dsn sentry) sentry)
+    (sentry-io/init! dsn sentry)
     (reset! http-requests-payload-stub [])))
 
-(defn close! [dsn]
+(defn close! [{:keys [dsn]}]
   (if-not (in-memory? dsn)
     (sentry-io/close!)
     (reset! http-requests-payload-stub nil)))

--- a/src/spootnik/reporter/sentry.clj
+++ b/src/spootnik/reporter/sentry.clj
@@ -54,7 +54,13 @@
    :query-string (-> payload :query-string)
    :headers      (-> payload :headers)})
 
-(defn e->sentry-event [e options tags]
+(defn e->sentry-event
+  "
+  Supported event keys:
+  https://github.com/getsentry/sentry-clj/tree/master?tab=readme-ov-file#supported-event-keys
+  "
+
+  [e options tags]
   (let [{:keys [message extra throwable]} e
         message      (or message (ex-message e))
         user         (some-> extra :org/uuid str)
@@ -92,7 +98,13 @@
 
       (swap! http-requests-payload-stub conj event))))
 
-(defn init! [{:keys [dsn] :as sentry}]
+(defn init!
+  "
+  Additional options can be found here:
+  https://github.com/getsentry/sentry-clj/tree/master?tab=readme-ov-file#additional-initialisation-options
+  "
+
+  [{:keys [dsn] :as sentry}]
   (if-not (in-memory? dsn)
     (sentry-io/init! dsn sentry)
     (reset! http-requests-payload-stub [])))

--- a/test/spootnik/reporter/impl_test.clj
+++ b/test/spootnik/reporter/impl_test.clj
@@ -7,7 +7,7 @@
             [prometheus.core :as prometheus]
             [spootnik.reporter.impl :refer :all]
             [com.stuartsierra.component :as component]
-            [raven.client :refer [http-requests-payload-stub]]
+            [spootnik.reporter.sentry :refer [http-requests-payload-stub]]
             [clojure.set :as cljset])
   (:import io.prometheus.client.CollectorRegistry
            io.netty.handler.ssl.SslContextBuilder


### PR DESCRIPTION
- Migration to sentry-clj library.
- Getting rid of unsupported raven library.