### PR TITLE
sentry: allow passing base tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Reporter provides a [component](https://github.com/stuartsierra/component) in or
 #### 1.0.0
 
 - Migrating from `exoscale/raven` to `io.sentry/sentry-clj`
+  - `SENTRY_` env vars are no longer automatically forwarded 
 - `raven-options` renamed to `sentry-options` within `spootnik.reporter.impl/Reporter` signature
 
 #### 0.2.0

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Reporter provides a [component](https://github.com/stuartsierra/component) in or
 
 ### Changelog
 
+#### 1.0.2
+
+- Migrating from `exoscale/raven` to `io.sentry/sentry-clj`
+- Reporter's `sentry` config supports the following keys `:dsn, :environment, :release, :tags`
+  - `sentry-options` are deprecated 
+
 #### 1.0.0
 
 - Migrating from `exoscale/raven` to `io.sentry/sentry-clj`

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Reporter provides a [component](https://github.com/stuartsierra/component) in or
 
 #### 1.0.2
 
-- Migrating from `exoscale/raven` to `io.sentry/sentry-clj`
 - Reporter's `sentry` config supports the following keys `:dsn, :environment, :release, :tags`
   - `sentry-options` are deprecated 
 

--- a/src/spootnik/reporter/impl.clj
+++ b/src/spootnik/reporter/impl.clj
@@ -523,7 +523,7 @@
   (capture! [this e]
     (capture! this e {}))
   (capture! [_this e tags]
-    (rs/send-event! (:dsn sentry) sentry-options e tags))
+    (rs/send-event! sentry sentry-options e tags))
   RiemannSink
   (send! [_this ev]
     (when rclient

--- a/src/spootnik/reporter/sentry.clj
+++ b/src/spootnik/reporter/sentry.clj
@@ -106,10 +106,10 @@
   "
   [{:keys [dsn] :as sentry}]
   (if-not (in-memory? dsn)
-    (sentry-io/init! dsn sentry)
+    (sentry/init! dsn sentry)
     (reset! http-requests-payload-stub [])))
 
 (defn close! [{:keys [dsn]}]
   (if-not (in-memory? dsn)
-    (sentry-io/close!)
+    (sentry/close!)
     (reset! http-requests-payload-stub nil)))

--- a/src/spootnik/reporter/sentry.clj
+++ b/src/spootnik/reporter/sentry.clj
@@ -1,7 +1,6 @@
 (ns spootnik.reporter.sentry
   (:require
     [sentry-clj.core :as sentry]
-    [sentry-clj.core :as sentry-io]
     [manifold.deferred :as d]
     [clojure.string :as str]
     [clojure.tools.logging :refer [error]]
@@ -85,7 +84,7 @@
   (let [event (e->sentry-event e (merge legacy-options sentry) tags)]
     (if-not (in-memory? dsn)
       (-> (try
-            (sentry-io/send-event event)
+            (sentry/send-event event)
             (catch Exception e
               (d/error-deferred e)))
 

--- a/src/spootnik/reporter/sentry.clj
+++ b/src/spootnik/reporter/sentry.clj
@@ -82,7 +82,6 @@
       request           (assoc :request request))))
 
 (defn send-event! [{:keys [dsn] :as sentry} legacy-options e tags]
-  ;; sentry-options are legacy
   (let [event (e->sentry-event e (merge legacy-options sentry) tags)]
     (if-not (in-memory? dsn)
       (-> (try

--- a/src/spootnik/reporter/sentry.clj
+++ b/src/spootnik/reporter/sentry.clj
@@ -1,10 +1,11 @@
 (ns spootnik.reporter.sentry
   (:require
-   [sentry-clj.core :as sentry-io]
-   [manifold.deferred  :as d]
-   [clojure.string :as str]
-   [clojure.tools.logging :refer [error]]
-   [clojure.java.shell :as sh]))
+    [sentry-clj.core :as sentry]
+    [sentry-clj.core :as sentry-io]
+    [manifold.deferred :as d]
+    [clojure.string :as str]
+    [clojure.tools.logging :refer [error]]
+    [clojure.java.shell :as sh]))
 
 (def http-requests-payload-stub
   "Storage for stubbed http sentry events "
@@ -59,28 +60,30 @@
   Supported event keys:
   https://github.com/getsentry/sentry-clj/tree/master?tab=readme-ov-file#supported-event-keys
   "
-
   [e options tags]
-  (let [{:keys [message extra throwable]} e
+  (let [{:keys [message extra throwable fingerprint]} e
         message      (or message (ex-message e))
         user         (some-> extra :org/uuid str)
-        fingerprints (some-> options :fingerpint seq)
-        request      (some-> extra :payload payload->sentry-request)]
+        fingerprints (some-> fingerprint seq)
+        request      (some-> extra :payload payload->sentry-request)
+        ;; override "base" tags with params
+        merged-tags  (merge (:tags options) tags)]
 
     (cond-> {:message message
              :level :error
              :platform "java"
              :server-name  (localhost)}
 
-      throwable    (assoc :throwable throwable)
-      extra        (assoc :extra extra)
-      (seq tags)   (assoc :tags tags)
-      user         (assoc :user user)
-      fingerprints (assoc :fingerprints fingerprints)
-      request      (assoc :request request))))
+      throwable         (assoc :throwable throwable)
+      extra             (assoc :extra extra)
+      (seq merged-tags) (assoc :tags merged-tags)
+      user              (assoc :user user)
+      fingerprints      (assoc :fingerprints fingerprints)
+      request           (assoc :request request))))
 
-(defn send-event! [dsn options e tags]
-  (let [event (e->sentry-event e options tags)]
+(defn send-event! [{:keys [dsn] :as sentry} legacy-options e tags]
+  ;; sentry-options are legacy
+  (let [event (e->sentry-event e (merge legacy-options sentry) tags)]
     (if-not (in-memory? dsn)
       (-> (try
             (sentry-io/send-event event)
@@ -93,8 +96,8 @@
              event-id))
 
           (d/catch (fn [e']
-                     (error e "Failed to capture exception" {:tags tags :capture-exception e'})
-                     (send-event! dsn options e' tags))))
+                     (error e "Failed to capture exception" {:tags tags :throwble e'})
+                     (send-event! sentry legacy-options e' tags))))
 
       (swap! http-requests-payload-stub conj event))))
 
@@ -103,7 +106,6 @@
   Additional options can be found here:
   https://github.com/getsentry/sentry-clj/tree/master?tab=readme-ov-file#additional-initialisation-options
   "
-
   [{:keys [dsn] :as sentry}]
   (if-not (in-memory? dsn)
     (sentry-io/init! dsn sentry)

--- a/src/spootnik/reporter/sentry.clj
+++ b/src/spootnik/reporter/sentry.clj
@@ -96,7 +96,7 @@
              event-id))
 
           (d/catch (fn [e']
-                     (error e "Failed to capture exception" {:tags tags :throwble e'})
+                     (error e "Failed to capture exception" {:tags tags :throwable e'})
                      (send-event! sentry legacy-options e' tags))))
 
       (swap! http-requests-payload-stub conj event))))


### PR DESCRIPTION
The java sdk seems to set `isEnableExternalConfiguration` by default (reading from env vars), or at the very least allows setting that option, while the clj sdk does not. The sentry-clj library is initiated without this option; it's also not possible to set it to `true`, hence we need a way to forwared some options to the sentry library.

This PR forwards the `tags`; `environment` and `release` could already be passed down

https://docs.sentry.io/platforms/java/configuration/#configuration-methods
https://github.com/getsentry/sentry-clj/?tab=readme-ov-file#additional-initialisation-options