### PR TITLE
bump sentry-clj to allow passing :enable-external-configuration

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
  {org.clojure/clojure        "1.9.0"
   org.clojure/tools.logging  "0.4.0"
   com.stuartsierra/component "0.3.2"
-  io.sentry/sentry-clj       "7.4.213"
+  io.sentry/sentry-clj       "7.6.215"
   spootnik/net               "0.3.3-beta24"
   spootnik/uncaught          "0.5.3"
   metrics-clojure            "2.10.0"

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [org.clojure/clojure                    "1.10.1"]
                  [org.clojure/tools.logging              "1.0.0"]
                  [com.stuartsierra/component             "1.0.0"]
-                 [io.sentry/sentry-clj                   "7.4.213"]
+                 [io.sentry/sentry-clj                   "7.6.215"]
                  [spootnik/uncaught                      "0.5.5"]
                  [metrics-clojure                        "2.10.0"]
                  [metrics-clojure-riemann                "2.10.0"]

--- a/src/spootnik/reporter/sentry.clj
+++ b/src/spootnik/reporter/sentry.clj
@@ -107,9 +107,10 @@
   Additional options can be found here:
   https://github.com/getsentry/sentry-clj/tree/master?tab=readme-ov-file#additional-initialisation-options
   "
-  [{:keys [dsn enable-external-configuration] :or {enable-external-configuration true} :as sentry}]
+  [{:keys [dsn] :as sentry}]
   (if-not (in-memory? dsn)
-    (sentry/init! dsn sentry)
+    (let [defaults {:enable-external-configuration true}]
+      (sentry/init! dsn (merge defaults sentry)))
     (reset! http-requests-payload-stub [])))
 
 (defn close! [{:keys [dsn]}]

--- a/src/spootnik/reporter/sentry.clj
+++ b/src/spootnik/reporter/sentry.clj
@@ -101,10 +101,13 @@
 
 (defn init!
   "
+  Initializes sentry. By default, external configuration is enabled.
+  Environment variables to options are documented here: https://docs.sentry.io/platforms/java/configuration/
+
   Additional options can be found here:
   https://github.com/getsentry/sentry-clj/tree/master?tab=readme-ov-file#additional-initialisation-options
   "
-  [{:keys [dsn] :as sentry}]
+  [{:keys [dsn enable-external-configuration] :or {enable-external-configuration true} :as sentry}]
   (if-not (in-memory? dsn)
     (sentry/init! dsn sentry)
     (reset! http-requests-payload-stub [])))


### PR DESCRIPTION
- Allow configuring `enable-external-configuration`, which is set to `true` by default 