### PR TITLE
reporter/report-error: allow reporting a message with extra data

### DIFF
--- a/src/spootnik/reporter.clj
+++ b/src/spootnik/reporter.clj
@@ -79,13 +79,13 @@
 
   ([error extra]
    (log/error error)
-   (-> (capture! (if (instance? Exception error)
-                   {:extra extra
-                    :throwable error}
-                   {:message error}))
-       (d/catch Throwable
-                (fn [e]
-                  (log/error e "Sentry failure")))
-       (try
-         (catch Throwable e
-           (log/error e "Sentry failure"))))))
+   (let [payload (cond-> {:extra extra}
+                   (instance? Exception error) (assoc :throwable error)
+                   (:message error) (assoc :message (:message error)))]
+     (-> (capture! payload)
+         (d/catch Throwable
+                  (fn [e]
+                    (log/error e "Sentry failure")))
+         (try
+           (catch Throwable e
+             (log/error e "Sentry failure")))))))

--- a/test/spootnik/reporter/reporter_test.clj
+++ b/test/spootnik/reporter/reporter_test.clj
@@ -1,0 +1,19 @@
+(ns spootnik.reporter.reporter-test 
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [spootnik.reporter :as sut]))
+
+(deftest report-error-test
+  (with-redefs [sut/capture! identity] 
+    (testing "with message"
+      (is (= {:message "error message" :extra {:foo "bar"}}
+             (sut/report-error {:message "error message"}
+                               {:foo "bar"}))))
+
+    (testing "with exception"
+      (let [e (ex-info "Exception" {:some :more-data}
+                       (ex-info "Root exception" {:some :data}))]
+        (is (= {:throwable e :extra {:foo "bar"}}
+               (sut/report-error e
+                                 {:foo "bar"})))))))
+


### PR DESCRIPTION
It seems that since [this change](https://github.com/exoscale/reporter/commit/c3fa4f4c6e9273a899a723dd74efa87c3a7768e5#diff-1d086718b79e44223815f06018dd5b132dbd6a516a4437241c8a76a3aedcd7dcL83-R85) we lost the ability to provide a message plus some extra data. Allowed the fn to accept the `:extra` params along the hash map with the `:message` field.