### PR TITLE
spec: spootnik.reporter.config/tls should be nilable

### DIFF
--- a/src/spootnik/reporter/specs.clj
+++ b/src/spootnik/reporter/specs.clj
@@ -20,7 +20,7 @@
 (s/def :spootnik.reporter.config/port pos-int?)
 (s/def :spootnik.reporter.config/host string?)
 (s/def :spootnik.reporter.config/protocol string?)
-(s/def :spootnik.reporter.config/tls :spootnik.reporter.config/ssl-cert)
+(s/def :spootnik.reporter.config/tls (s/nilable :spootnik.reporter.config/ssl-cert))
 (s/def :spootnik.reporter.config/endpoint (s/and string? #(str/starts-with? % "/")))
 
 ;; riemann


### PR DESCRIPTION
This will make the configs easier to write, currently if we validate the spec, we have to place the `#profile` on the entire block and we can't put it just on the `:tls` key