### PR TITLE
feat(pushgateway): allow pushing at a later time

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -10,6 +10,10 @@ jobs:
         - 9091:9091/tcp
     steps:
     - uses: actions/checkout@v2
+    - name: Install clojure tools
+      uses: DeLaGuardo/setup-clojure@13.0
+      with:
+        lein: 2.11.2
     - name: Install dependencies
       run: lein deps
     - name: Run tests

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Reporter provides a [component](https://github.com/stuartsierra/component) in or
 
 #### 1.0.6
 
-- Allow metrics sent via `gauge!` and `counter!` from sending to pushgateway so metrics can be sent at a later time
+- Allow metrics sent via `gauge!` and `counter!` to delay sending to pushgateway
   - pass `(reporter/gauge!  {... push? false})` 
   - introduce `push-metrics!` to flush metrics to pushgateway 
  

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Reporter provides a [component](https://github.com/stuartsierra/component) in or
 
 ### Changelog
 
+#### 1.0.6
+
+- Allow metrics sent via `gauge!` and `counter!` from sending to pushgateway so metrics can be sent at a later time
+  - pass `(reporter/gauge!  {... push? false})` 
+  - introduce `push-metrics!` to flush metrics to pushgateway 
+ 
 #### 1.0.2
 
 - Reporter's `sentry` config supports the following keys `:dsn, :environment, :release, :tags`

--- a/test/spootnik/reporter/impl_test.clj
+++ b/test/spootnik/reporter/impl_test.clj
@@ -160,12 +160,15 @@
           (condp = type
             :counter
             (.counter! ^spootnik.reporter.impl.PushGatewaySink reporter (cond-> {:name         name
-                                                                                 :label-values label-values}
+                                                                                 :label-values label-values
+                                                                                 :push? false}
                                                                           (not= 0 value) (assoc :value value)))
             :gauge
             (.gauge! ^spootnik.reporter.impl.PushGatewaySink reporter {:name name
                                                                        :value value
                                                                        :label-values label-values}))))
+      ;; push remaining metrics
+      (push-metrics! reporter)
 
       (let [pg-metrics (-> @(http/get "http://localhost:9091/metrics")
                            :body


### PR DESCRIPTION
Rationale is that if we are somehow measuring elapsed time, we don't want to pollute our timings with pushgateway push
```
(let [start (System/currentTimeMillis)]
  (reporter/gauge! {:some "other metric"}) ;; we dont want the elapsed time to include this metrics push
  ...
  (reporter/gauge! {:some "metric} (- (System/currentTimeMillis) start)))
```

This would become:
```
(let [start (System/currentTimeMillis)]
  (try
    (reporter/gauge! {:some "other metric" :push? false})
    ...
    (reporter/gauge! {:some "metric :push? false} (- (System/currentTimeMillis) start)
    (finally 
      (reporter/push-metrics!)))
```
