### PR TITLE
add support for otlp metrics

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -14,5 +14,15 @@ jobs:
       uses: DeLaGuardo/setup-clojure@13.1
       with:
         cli: 1.10.1.693
+
+    - name: Setup docker compose
+      uses: hoverkraft-tech/compose-action@v2.2.0
+      with:
+        compose-file: |
+          docker-compose.yaml
+        up-flags: "--no-build -d --pull=missing --quiet-pull"
+        down-flags: "--volumes"
+        compose-version: "2.36.0"
+
     - name: Run tests
       run: clojure -X:test

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -16,13 +16,15 @@ jobs:
         cli: 1.10.1.693
 
     - name: Setup docker compose
-      uses: hoverkraft-tech/compose-action@v2.2.0
+      uses: hoverkraft-tech/compose-action@v2.0.1
       with:
-        compose-file: |
-          docker-compose.yaml
-        up-flags: "--no-build -d --pull=missing --quiet-pull"
-        down-flags: "--volumes"
-        compose-version: "2.36.0"
+        compose-file: "./docker-compose.yaml"
+        services: |
+          pushgateway
+          otel-collector
+
+    - name: Check services
+      run: docker compose ps
 
     - name: Run tests
       run: clojure -X:test

--- a/README.md
+++ b/README.md
@@ -21,10 +21,20 @@ Reporter provides a [component](https://github.com/stuartsierra/component) in or
 
 ### Changelog
 
+#### 1.0.220
+
+- Allow pushing metrics to open telemetry via an additional `reporter` (similar to : 
+```clojure
+:otel {:endpoint      "http://localhost:4317"
+       :job           "testing"
+       :grouping-keys {:cluster "testing-cluster"}}
+```
+
 #### 1.0.218
 
 - Use `deps.edn` for build
 - Sentry exceptions are now sent as the `throwable` field
+
 
 #### 1.0.7
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,15 @@ Reporter provides a [component](https://github.com/stuartsierra/component) in or
 
 #### 1.0.220
 
-- Allow pushing metrics to open telemetry via an additional `reporter` (similar to : 
+- Allow pushing metrics to open telemetry via an additional `reporter` (similar to `pushgateway`)
+  - if OpenTelemetry SDK is already initialized, `initialize-sdk?` should be `false`
+  - if OpenTelemetry SDK was not initialized, an exception may occur: `java.lang.ClassCastException: io.opentelemetry.api.metrics.DefaultMeterProvider cannot be cast to io.opentelemetry.sdk.metrics.SdkMeterProvider`
+
 ```clojure
-:otel {:endpoint      "http://localhost:4317"
-       :job           "testing"
-       :grouping-keys {:cluster "testing-cluster"}}
+:otel {:endpoint        "http://localhost:4317"
+       :job             "testing"
+       :grouping-keys   {:cluster "testing-cluster"}
+       :initialize-sdk? true}
 ```
 
 #### 1.0.218

--- a/build.clj
+++ b/build.clj
@@ -52,6 +52,14 @@
               :repository "clojars"})
   opts)
 
+(defn install [{:keys [lib version jar-file]}]
+  (jar {})
+  (b/install {:basis @basis
+              :class-dir class-dir
+              :lib lib
+              :version version
+              :jar-file jar-file}))
+
 (defn- sh
   [& cmds]
   (doseq [cmd cmds]

--- a/deps.edn
+++ b/deps.edn
@@ -39,6 +39,7 @@
   :test
   {:extra-deps {exoscale/test-runner {:local/root "dev"}
                 com.soundcloud/prometheus-clj {:mvn/version "2.4.1"}
+                nubank/matcher-combinators {:mvn/version "3.9.1"}
                 org.slf4j/slf4j-api {:mvn/version "1.7.26"}
                 org.slf4j/slf4j-log4j12 {:mvn/version "1.7.26"}
                 org.clojure/tools.logging {:mvn/version "1.3.0"}}

--- a/deps.edn
+++ b/deps.edn
@@ -13,6 +13,15 @@
   metrics-clojure-riemann/metrics-clojure-riemann {:mvn/version "2.10.0"}
   metrics-clojure-jvm/metrics-clojure-jvm {:mvn/version "2.10.0"}
   metrics-clojure-graphite/metrics-clojure-graphite {:mvn/version "2.10.0"}
+
+  io.opentelemetry/opentelemetry-sdk-metrics {:mvn/version "1.50.0"}
+  io.opentelemetry/opentelemetry-exporter-otlp {:mvn/version "1.50.0"}
+  ;; required to send over grpc
+  io.grpc/grpc-netty-shaded {:mvn/version "1.64.0"}
+  io.grpc/grpc-protobuf {:mvn/version "1.64.0"}
+  io.grpc/grpc-stub {:mvn/version "1.64.0"}
+  com.google.protobuf/protobuf-java {:mvn/version "3.25.0"}
+
   io.prometheus/simpleclient {:mvn/version "0.16.0"}
   io.prometheus/simpleclient_common {:mvn/version "0.16.0"}
   io.prometheus/simpleclient_hotspot {:mvn/version "0.16.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -39,7 +39,6 @@
   :test
   {:extra-deps {exoscale/test-runner {:local/root "dev"}
                 com.soundcloud/prometheus-clj {:mvn/version "2.4.1"}
-                nubank/matcher-combinators {:mvn/version "3.9.1"}
                 org.slf4j/slf4j-api {:mvn/version "1.7.26"}
                 org.slf4j/slf4j-log4j12 {:mvn/version "1.7.26"}
                 org.clojure/tools.logging {:mvn/version "1.3.0"}}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,3 +7,10 @@ services:
   pushgateway:
     image: prom/pushgateway
     network_mode: host
+
+  otel-collector:
+    image: otel/opentelemetry-collector:latest
+    command: ["--config=/etc/otel.yml"]
+    volumes:
+      - ./otel.yml:/etc/otel.yml
+    network_mode: host

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+version: '3.5'
+networks:
+  reporter:
+    name: "reporter_${NETWORK_SUFFIX}"
+
+services:
+  pushgateway:
+    image: prom/pushgateway
+    network_mode: host

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,3 @@
-version: '3.5'
-networks:
-  reporter:
-    name: "reporter_${NETWORK_SUFFIX}"
-
 services:
   pushgateway:
     image: prom/pushgateway

--- a/otel.yml
+++ b/otel.yml
@@ -1,0 +1,27 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4224
+
+processors:
+  batch:
+
+exporters:
+  debug:
+    verbosity: basic
+
+  prometheus:
+    endpoint: 0.0.0.0:9092
+    metric_expiration: 5m
+    send_timestamps: false
+    add_metric_suffixes: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug, prometheus]

--- a/src/spootnik/reporter/impl.clj
+++ b/src/spootnik/reporter/impl.clj
@@ -1,24 +1,25 @@
 (ns spootnik.reporter.impl
-  (:require [aleph.http                 :as http]
+  (:require [aleph.http :as http]
             [clojure.java.io :as io]
+            [clojure.tools.logging :as log]
             [com.stuartsierra.component :as c]
-            [metrics.reporters.console  :as console]
-            [metrics.reporters.jmx      :as jmx]
+            [metrics.reporters.console :as console]
+            [metrics.reporters.jmx :as jmx]
             [metrics.reporters.graphite :as graphite]
-            [metrics.reporters.riemann  :as riemann]
-            [spootnik.log-reporter      :as logs]
-            [metrics.jvm.core           :as jvm]
-            [metrics.core               :as m]
-            [metrics.gauges             :as gge]
-            [metrics.counters           :as cnt]
-            [metrics.meters             :as mtr]
-            [metrics.timers             :as tmr]
-            [metrics.histograms         :as hst]
-            [camel-snake-kebab.core     :as csk]
-            [clojure.string             :as str]
-            [clojure.tools.logging      :refer [info error]]
-            [spootnik.uncaught          :refer [with-uncaught]]
-            [spootnik.reporter.sentry   :as rs])
+            [metrics.reporters.riemann :as riemann]
+            [spootnik.log-reporter :as logs]
+            [metrics.jvm.core :as jvm]
+            [metrics.core :as m]
+            [metrics.gauges :as gge]
+            [metrics.counters :as cnt]
+            [metrics.meters :as mtr]
+            [metrics.timers :as tmr]
+            [metrics.histograms :as hst]
+            [camel-snake-kebab.core :as csk]
+            [clojure.string :as str]
+            [clojure.tools.logging :refer [info error]]
+            [spootnik.uncaught :refer [with-uncaught]]
+            [spootnik.reporter.sentry :as rs])
   (:import com.aphyr.riemann.client.RiemannClient
            com.aphyr.riemann.client.RiemannBatchClient
            com.aphyr.riemann.client.TcpTransport
@@ -59,6 +60,7 @@
            [io.opentelemetry.exporter.otlp.metrics OtlpGrpcMetricExporter]
            [io.opentelemetry.sdk OpenTelemetrySdk]
            [io.opentelemetry.sdk.metrics SdkMeterProvider]
+           [io.opentelemetry.api.metrics MeterProvider]
            [io.opentelemetry.sdk.metrics.export PeriodicMetricReader]
            [io.opentelemetry.sdk.resources Resource]
            [java.util.function Consumer]))
@@ -393,17 +395,34 @@
       (.inc (double value))))
 
 ;; open telemetry
-(defn- ^Attributes arr->attrs [kvs]
+(defn- ^Attributes arr->raw-attrs [kvs-arr]
   (let [builder (Attributes/builder)]
-    (doseq [[k v] (partition 2 kvs)]
+    (doseq [[k v] (partition 2 kvs-arr)]
       (.put builder ^String (name k) ^String (name v)))
     (.build builder)))
+(defn- ^Attributes arr->attrs [kvs-arr]
+  (->> (apply hash-map kvs-arr)
+       (reduce-kv (fn [m k v]
+                    (cond
+                      (= "job" (name k))
+                      (do
+                        (log/warn "'instance' cannot be an attribute label, it is derived from OTEL 'service.name' ")
+                        m)
+                      (= "instance" (name k))
+                      (do
+                        (log/warn "'instance' cannot be an attribute label, it is derived from OTEL 'service.instance.id' ")
+                        m)
+                      :else (assoc m k v))) {})
+       (apply concat)
+       (arr->raw-attrs)))
 
 (defmethod set-gauge! :otel
   [{:keys [metric label-names grouping-keys]} {:keys [label-values value]}]
+  ;; TODO ignore :instance
   (.set ^DoubleGauge metric (double value) (arr->attrs (concat (interleave label-names label-values)
                                                                (mapcat identity grouping-keys)))))
 (defmethod inc-counter! :otel
+  ;; TODO ignore :instance
   [{:keys [metric label-names grouping-keys]} {:keys [label-values value] :or {value 1}}]
   (.add ^LongCounter metric (long value) (arr->attrs (concat (interleave label-names label-values)
                                                              (mapcat identity grouping-keys)))))
@@ -412,18 +431,22 @@
   [^PushGateway pg ^CollectorRegistry registry ^String job ^java.util.Map grouping-keys]
   (.push pg registry job grouping-keys))
 
-(defn flush-otel-metrics! [{:keys [^SdkMeterProvider provider]}]
+(defn flush-otel-metrics! [{:keys [^MeterProvider provider]}]
   ;; flushes all metric readers
-  (-> (.forceFlush provider)
-      (.join 10 TimeUnit/SECONDS)))
+  ;; if we initialized the sdk, then we can flush
+  ;; otherwise we dont control it
+  (if (instance? SdkMeterProvider provider)
+    (-> (.forceFlush ^SdkMeterProvider provider)
+        (.join 10 TimeUnit/SECONDS))
+    (log/warnf "Cannot flush metrics: provider is not of class SdkMeterProvider: %s" (class provider))))
 
 (defn parse-pggrouping-keys [grouping-keys]
   (into {} (for [[k v] grouping-keys] [(csk/->snake_case_string k) v])))
 
-(defn build-otel-metrics [{:keys [endpoint job grouping-keys initialize-sdk?]} metrics-def]
+(defn build-otel-metrics [{:keys [endpoint job instance grouping-keys initialize-sdk?]} metrics-def]
   ;; https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/
   (let [provider (if initialize-sdk?
-                   (let [attrs    (arr->attrs ["service.name" job "service.instance.id" ""])
+                   (let [attrs    (arr->raw-attrs ["service.name" job "service.instance.id" instance])
                          resource (-> (Resource/getDefault)
                                       (.merge (Resource/create attrs)))
                          exporter (-> (OtlpGrpcMetricExporter/builder)
@@ -453,9 +476,10 @@
                                                  :grouping-keys (parse-pggrouping-keys grouping-keys)}))
                          {}
                          metrics-def)]
-    (-> (OpenTelemetrySdk/builder)
-        (.setMeterProvider provider)
-        (.buildAndRegisterGlobal))
+    (when initialize-sdk?
+      (-> (OpenTelemetrySdk/builder)
+          (.setMeterProvider provider)
+          (.buildAndRegisterGlobal)))
     {:provider provider
      :metrics metrics}))
 
@@ -532,9 +556,11 @@
       (when prometheus
         (.close ^java.io.Closeable (:server prometheus)))
       (when otel
-        (let [{:keys [^SdkMeterProvider provider]} otel]
-          (-> (.shutdown provider)
-              (.join 10 TimeUnit/SECONDS))))
+        (let [{:keys [^MeterProvider provider]} otel]
+          (if (instance? SdkMeterProvider provider)
+            (-> (.shutdown ^SdkMeterProvider provider)
+                (.join 10 TimeUnit/SECONDS))
+            (log/warnf "Shutdown not available: provider is not of class SdkMeterProvider: %s" (class provider)))))
 
       (rs/close! sentry))
 
@@ -611,7 +637,7 @@
         (when push?
           (push-pushgateway-metric! client registry job grouping-keys))))
     (when otel
-      (let [{:keys [^SdkMeterProvider provider metrics]} otel
+      (let [{:keys [^MeterProvider provider metrics]} otel
             impl (name metrics)]
         (inc-counter! impl metric)
         (when push?
@@ -625,7 +651,7 @@
         (when push?
           (push-pushgateway-metric! client registry job grouping-keys))))
     (when otel
-      (let [{:keys [^SdkMeterProvider provider metrics]} otel
+      (let [{:keys [^MeterProvider provider metrics]} otel
             impl (name metrics)]
         (set-gauge! impl metric)
         (when push?

--- a/src/spootnik/reporter/impl.clj
+++ b/src/spootnik/reporter/impl.clj
@@ -52,7 +52,12 @@
            java.security.cert.CertificateFactory
            javax.net.ssl.HttpsURLConnection
            io.netty.handler.ssl.JdkSslContext
-           javax.net.ssl.SSLContext))
+           javax.net.ssl.SSLContext
+           [io.opentelemetry.api GlobalOpenTelemetry]
+           [io.opentelemetry.exporter.otlp.metrics OtlpGrpcMetricExporter]
+           [io.opentelemetry.sdk OpenTelemetrySdk]
+           [io.opentelemetry.sdk.metrics SdkMeterProvider]
+           [io.opentelemetry.sdk.metrics.export PeriodicMetricReader]))
 
 (defprotocol RiemannSink
   (send! [this e]))
@@ -175,7 +180,16 @@
       (info "Clearing pushgateway registry")
       (.clear registry))))
 
-(defn build-metrics-reporter [reg rclient ^CollectorRegistry prometheus-registry ^CollectorRegistry pushgateway-registry [type opt]]
+(defn build-otel-metrics-reporter [reg otel {:keys [opts]}]
+  (reify
+    c/Lifecycle
+    (start [this]
+      (info "Starting otel reporter")
+      this)
+    (stop [this]
+      (info "Clearing otel registry"))))
+
+(defn build-metrics-reporter [reg rclient otel ^CollectorRegistry prometheus-registry ^CollectorRegistry pushgateway-registry [type opt]]
   (condp = type
     :console  (build-console-metrics-reporter reg opt)
     :logs     (build-logs-metrics-reporter reg opt)
@@ -184,6 +198,7 @@
     :riemann  (build-riemann-metrics-reporter reg rclient opt)
     :prometheus (build-prometheus-metrics-reporter reg prometheus-registry)
     :pushgateway (build-pushgateway-metrics-reporter pushgateway-registry)
+    :otel (build-otel-metrics-reporter reg otel opt)
     :else (throw (ex-info "Cannot build requested metrics reporter" type))))
 
 (defn riemann-client
@@ -235,14 +250,14 @@
          (deref'))))
 
 (defn build-metrics-reporters
-  [reg reporters rclient ^CollectorRegistry prometheus-registry pushgateway-registry]
+  [reg reporters rclient otel ^CollectorRegistry prometheus-registry pushgateway-registry]
   (info "building metrics reporters")
-  (mapv (partial build-metrics-reporter reg rclient prometheus-registry pushgateway-registry) reporters))
+  (mapv (partial build-metrics-reporter reg rclient otel prometheus-registry pushgateway-registry) reporters))
 
 (defn build-metrics
-  [{:keys [reporters]} rclient ^CollectorRegistry prometheus-registry pushgateway-registry]
+  [{:keys [reporters]} rclient otel ^CollectorRegistry prometheus-registry pushgateway-registry]
   (let [reg  (m/new-registry)
-        reps (build-metrics-reporters reg reporters rclient prometheus-registry pushgateway-registry)]
+        reps (build-metrics-reporters reg reporters rclient otel prometheus-registry pushgateway-registry)]
     (doseq [r reps]
       (c/start r))
     [reg reps]))
@@ -369,15 +384,36 @@
   [^PushGateway pg ^CollectorRegistry registry ^String job ^java.util.Map grouping-keys]
   (.push pg registry job grouping-keys))
 
+(defn flush-otel-metrics! [{:keys [^SdkMeterProvider provider]}]
+  ;; flushes all metric readers
+  (-> (.forceFlush provider)
+      (.join 10 TimeUnit/SECONDS)))
+
+(defn build-otel-components [{:keys [endpoint svc-name svc-version tls]}]
+  (let [exporter (-> (OtlpGrpcMetricExporter/builder)
+                     (.setEndpoint endpoint)
+                     (.setTimeout 2 TimeUnit/SECONDS)
+                     (.build))
+        provider (-> (SdkMeterProvider/builder)
+                     (.registerMetricReader (PeriodicMetricReader/create exporter))
+                     (.build))]
+    (-> (OpenTelemetrySdk/builder)
+        (.setMeterProvider provider)
+        (.buildAndRegisterGlobal))
+    {:exporter exporter
+     :provider provider}))
+
 (defn parse-pggrouping-keys [grouping-keys]
   (into {} (for [[k v] grouping-keys] [(csk/->snake_case_string k) v])))
+
 
 ;; Reporter configuration specs:
 ;; https://github.com/exoscale/reporter/blob/master/src/spootnik/reporter/specs.clj
 
 (defrecord Reporter [rclient sentry-options reporters registry sentry
                      metrics riemann prevent-capture? prometheus
-                     started? pushgateway]
+                     started? pushgateway
+                     otel]
   c/Lifecycle
   (start [this]
     (if started?
@@ -389,7 +425,8 @@
                                                                            (parse-pggrouping-keys (:grouping-keys pushgateway))])
             pgmetrics            (when pushgateway (build-collectors! pgregistry (get-in metrics [:reporters :pushgateway])))
             rclient              (when riemann (riemann-client riemann))
-            [reg reps]           (build-metrics metrics rclient prometheus-registry pgregistry)
+            otel                 (when otel (build-otel-components))
+            [reg reps]           (build-metrics metrics rclient otel prometheus-registry pgregistry)
             options              (when sentry (or sentry-options {}))
             prometheus-server    (when prometheus
                                    (let [tls (:tls prometheus)
@@ -424,7 +461,8 @@
                                            :registry pgregistry
                                            :grouping-keys pggrouping-keys
                                            :metrics pgmetrics
-                                           :job pgjob})))))
+                                           :job pgjob})
+          otel (assoc :otel otel)))))
   (stop [this]
     (when started?
       (when-not prevent-capture?
@@ -441,6 +479,10 @@
           (catch Exception _)))
       (when prometheus
         (.close ^java.io.Closeable (:server prometheus)))
+      (when otel
+        (let [{:keys [^SdkMeterProvider provider]} otel]
+          (-> (.shutdown provider)
+              (.join 10 TimeUnit/SECONDS))))
 
       (rs/close! sentry))
 
@@ -451,6 +493,7 @@
            :rclient nil
            :prometheus nil
            :pushgateway nil
+           :otel nil
            :started? false))
   MetricHolder
   (instrument! [this prefix]
@@ -525,7 +568,9 @@
   (push-metrics! [this]
     (when pushgateway
       (let [{:keys [client job registry grouping-keys]} pushgateway]
-        (push-pushgateway-metric! client registry job grouping-keys))))
+        (push-pushgateway-metric! client registry job grouping-keys)))
+    (when otel
+      (flush-otel-metrics! otel)))
   SentrySink
   (capture! [this e]
     (capture! this e {}))

--- a/src/spootnik/reporter/impl.clj
+++ b/src/spootnik/reporter/impl.clj
@@ -184,14 +184,11 @@
       (info "Clearing pushgateway registry")
       (.clear registry))))
 
-(defn build-otel-metrics-reporter [reg otel {:keys [opts]}]
+(defn build-otel-metrics-reporter [reg {:keys [job endpoint]} {:keys [opts]}]
   (reify
     c/Lifecycle
-    (start [this]
-      (info "Starting otel reporter")
-      this)
-    (stop [this]
-      (info "Clearing otel registry"))))
+    (start [this] this)
+    (stop [this] this)))
 
 (defn build-metrics-reporter [reg rclient otel ^CollectorRegistry prometheus-registry ^CollectorRegistry pushgateway-registry [type opt]]
   (condp = type
@@ -479,8 +476,8 @@
                                                                            (parse-pggrouping-keys (:grouping-keys pushgateway))])
             pgmetrics            (when pushgateway (build-collectors! pgregistry (get-in metrics [:reporters :pushgateway])))
             rclient              (when riemann (riemann-client riemann))
-            otel                 (when otel (build-otel-metrics otel (get-in metrics [:reporters :otel])))
             [reg reps]           (build-metrics metrics rclient otel prometheus-registry pgregistry)
+            otel                 (when otel (build-otel-metrics otel (get-in metrics [:reporters :otel])))
             options              (when sentry (or sentry-options {}))
             prometheus-server    (when prometheus
                                    (let [tls (:tls prometheus)

--- a/src/spootnik/reporter/impl.clj
+++ b/src/spootnik/reporter/impl.clj
@@ -53,7 +53,7 @@
            javax.net.ssl.HttpsURLConnection
            io.netty.handler.ssl.JdkSslContext
            javax.net.ssl.SSLContext
-           [io.opentelemetry.api GlobalOpenTelemetry]
+           [io.opentelemetry.api GlobalOpenTelemetry OpenTelemetry]
            [io.opentelemetry.api.common AttributeKey Attributes]
            [io.opentelemetry.api.metrics DoubleGauge LongCounter ObservableLongMeasurement]
            [io.opentelemetry.exporter.otlp.metrics OtlpGrpcMetricExporter]
@@ -420,19 +420,22 @@
 (defn parse-pggrouping-keys [grouping-keys]
   (into {} (for [[k v] grouping-keys] [(csk/->snake_case_string k) v])))
 
-(defn build-otel-metrics [{:keys [endpoint job grouping-keys]} metrics-def]
+(defn build-otel-metrics [{:keys [endpoint job grouping-keys initialize-sdk?]} metrics-def]
   ;; https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/
-  (let [attrs    (arr->attrs ["service.name" job "service.instance.id" ""])
-        resource (-> (Resource/getDefault)
-                    (.merge (Resource/create attrs)))
-        exporter (-> (OtlpGrpcMetricExporter/builder)
-                     (.setEndpoint endpoint)
-                     (.setTimeout 2 TimeUnit/SECONDS)
-                     (.build))
-        provider (-> (SdkMeterProvider/builder)
-                     (.setResource resource)
-                     (.registerMetricReader (PeriodicMetricReader/create exporter))
-                     (.build))
+  (let [provider (if initialize-sdk?
+                   (let [attrs    (arr->attrs ["service.name" job "service.instance.id" ""])
+                         resource (-> (Resource/getDefault)
+                                      (.merge (Resource/create attrs)))
+                         exporter (-> (OtlpGrpcMetricExporter/builder)
+                                      (.setEndpoint endpoint)
+                                      (.setTimeout 2 TimeUnit/SECONDS)
+                                      (.build))]
+                     (-> (SdkMeterProvider/builder)
+                         (.setResource resource)
+                         (.registerMetricReader (PeriodicMetricReader/create exporter))
+                         (.build)))
+                   ;; else
+                   (.getMeterProvider (GlobalOpenTelemetry/get)))
         mbuilder (.build (.meterBuilder provider "exoscale.reporter"))
         make-fn  (fn [{:keys [name help type label-names]}]
                    (condp = type
@@ -453,9 +456,7 @@
     (-> (OpenTelemetrySdk/builder)
         (.setMeterProvider provider)
         (.buildAndRegisterGlobal))
-
-    {:exporter exporter
-     :provider provider
+    {:provider provider
      :metrics metrics}))
 
 ;; Reporter configuration specs:

--- a/src/spootnik/reporter/impl.clj
+++ b/src/spootnik/reporter/impl.clj
@@ -406,11 +406,11 @@
                     (cond
                       (= "job" (name k))
                       (do
-                        (log/warn "'instance' cannot be an attribute label, it is derived from OTEL 'service.name' ")
+                        (log/warn "'job' attribute for OTEL metric will be dropped, it is derived from OTEL 'service.name' ")
                         m)
                       (= "instance" (name k))
                       (do
-                        (log/warn "'instance' cannot be an attribute label, it is derived from OTEL 'service.instance.id' ")
+                        (log/warn "'instance' for OTEL metric will be dropped, it is derived from OTEL 'service.instance.id' ")
                         m)
                       :else (assoc m k v))) {})
        (apply concat)

--- a/src/spootnik/reporter/impl.clj
+++ b/src/spootnik/reporter/impl.clj
@@ -54,10 +54,14 @@
            io.netty.handler.ssl.JdkSslContext
            javax.net.ssl.SSLContext
            [io.opentelemetry.api GlobalOpenTelemetry]
+           [io.opentelemetry.api.common AttributeKey Attributes]
+           [io.opentelemetry.api.metrics DoubleGauge LongCounter ObservableLongMeasurement]
            [io.opentelemetry.exporter.otlp.metrics OtlpGrpcMetricExporter]
            [io.opentelemetry.sdk OpenTelemetrySdk]
            [io.opentelemetry.sdk.metrics SdkMeterProvider]
-           [io.opentelemetry.sdk.metrics.export PeriodicMetricReader]))
+           [io.opentelemetry.sdk.metrics.export PeriodicMetricReader]
+           [io.opentelemetry.sdk.resources Resource]
+           [java.util.function Consumer]))
 
 (defprotocol RiemannSink
   (send! [this e]))
@@ -367,18 +371,45 @@
                                                  (register-pushgateway-collector registry))])
                 metrics)))
 
-(defn set-gauge!
+;; these can work with Pushgateway Gauge/Counter or open telemetry
+(defmulti set-gauge! "Set the given `gauge` with the opts"
+          (fn [gauge opts]
+            (cond
+              (map? gauge) :otel
+              (instance? io.prometheus.client.SimpleCollector gauge) :prometheus)))
+(defmulti inc-counter! "Increment the given `counter` with the opts"
+          (fn [counter opts]
+            (cond
+              (map? counter) :otel
+              (instance? io.prometheus.client.SimpleCollector counter) :prometheus)))
+
+;; pushgateway
+(defmethod set-gauge! :prometheus
   [^Gauge gauge {:keys [label-values value]}]
   (-> gauge
       ^Gauge$Child (.labels (into-array String (map name label-values)))
       (.set ^double value)))
-
-(defn inc-counter!
-  "Increment the given `counter` with optional increment `value`."
+(defmethod inc-counter! :prometheus
   [^Counter counter {:keys [value label-values] :or {value 1}}]
   (-> counter
       ^Counter$Child (.labels (into-array String (map name label-values)))
       (.inc (double value))))
+
+;; open telemetry
+(defn- ^Attributes arr->attrs [kvs]
+  (let [builder (Attributes/builder)]
+    (doseq [[k v] (partition 2 kvs)]
+      (.put builder ^String (name k) ^String (name v)))
+    (.build builder)))
+
+(defmethod set-gauge! :otel
+  [{:keys [metric label-names grouping-keys]} {:keys [label-values value]}]
+  (.set ^DoubleGauge metric (double value) (arr->attrs (concat (interleave label-names label-values)
+                                                               (mapcat identity grouping-keys)))))
+(defmethod inc-counter! :otel
+  [{:keys [metric label-names grouping-keys]} {:keys [label-values value] :or {value 1}}]
+  (.add ^LongCounter metric (long value) (arr->attrs (concat (interleave label-names label-values)
+                                                             (mapcat identity grouping-keys)))))
 
 (defn push-pushgateway-metric!
   [^PushGateway pg ^CollectorRegistry registry ^String job ^java.util.Map grouping-keys]
@@ -389,23 +420,46 @@
   (-> (.forceFlush provider)
       (.join 10 TimeUnit/SECONDS)))
 
-(defn build-otel-components [{:keys [endpoint svc-name svc-version tls]}]
-  (let [exporter (-> (OtlpGrpcMetricExporter/builder)
+(defn parse-pggrouping-keys [grouping-keys]
+  (into {} (for [[k v] grouping-keys] [(csk/->snake_case_string k) v])))
+
+(defn build-otel-metrics [{:keys [endpoint job grouping-keys]} metrics-def]
+  ;; https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/
+  (let [attrs    (arr->attrs ["service.name" job "service.instance.id" ""])
+        resource (-> (Resource/getDefault)
+                    (.merge (Resource/create attrs)))
+        exporter (-> (OtlpGrpcMetricExporter/builder)
                      (.setEndpoint endpoint)
                      (.setTimeout 2 TimeUnit/SECONDS)
                      (.build))
         provider (-> (SdkMeterProvider/builder)
+                     (.setResource resource)
                      (.registerMetricReader (PeriodicMetricReader/create exporter))
-                     (.build))]
+                     (.build))
+        mbuilder (.build (.meterBuilder provider "exoscale.reporter"))
+        make-fn  (fn [{:keys [name help type label-names]}]
+                   (condp = type
+                     :gauge (-> mbuilder
+                                (.gaugeBuilder (clojure.core/name name))
+                                (.setDescription help)
+                                (.build))
+                     :counter (-> mbuilder
+                                  (.counterBuilder (clojure.core/name name))
+                                  (.setDescription help)
+                                  (.build))))
+        metrics  (reduce (fn [acc m]
+                           (assoc acc (:name m) {:metric (make-fn m)
+                                                 :label-names (:label-names m)
+                                                 :grouping-keys (parse-pggrouping-keys grouping-keys)}))
+                         {}
+                         metrics-def)]
     (-> (OpenTelemetrySdk/builder)
         (.setMeterProvider provider)
         (.buildAndRegisterGlobal))
+
     {:exporter exporter
-     :provider provider}))
-
-(defn parse-pggrouping-keys [grouping-keys]
-  (into {} (for [[k v] grouping-keys] [(csk/->snake_case_string k) v])))
-
+     :provider provider
+     :metrics metrics}))
 
 ;; Reporter configuration specs:
 ;; https://github.com/exoscale/reporter/blob/master/src/spootnik/reporter/specs.clj
@@ -425,7 +479,7 @@
                                                                            (parse-pggrouping-keys (:grouping-keys pushgateway))])
             pgmetrics            (when pushgateway (build-collectors! pgregistry (get-in metrics [:reporters :pushgateway])))
             rclient              (when riemann (riemann-client riemann))
-            otel                 (when otel (build-otel-components))
+            otel                 (when otel (build-otel-metrics otel (get-in metrics [:reporters :otel])))
             [reg reps]           (build-metrics metrics rclient otel prometheus-registry pgregistry)
             options              (when sentry (or sentry-options {}))
             prometheus-server    (when prometheus
@@ -557,14 +611,27 @@
             collector (name metrics)]
         (inc-counter! collector metric)
         (when push?
-          (push-pushgateway-metric! client registry job grouping-keys)))))
+          (push-pushgateway-metric! client registry job grouping-keys))))
+    (when otel
+      (let [{:keys [^SdkMeterProvider provider metrics]} otel
+            impl (name metrics)]
+        (inc-counter! impl metric)
+        (when push?
+          (flush-otel-metrics! otel)))))
+
   (gauge! [this {:keys [name push?] :or {push? true}  :as metric}]
     (when pushgateway
       (let [{:keys [client metrics job registry grouping-keys]} pushgateway
             collector (name metrics)]
         (set-gauge! collector metric)
         (when push?
-          (push-pushgateway-metric! client registry job grouping-keys)))))
+          (push-pushgateway-metric! client registry job grouping-keys))))
+    (when otel
+      (let [{:keys [^SdkMeterProvider provider metrics]} otel
+            impl (name metrics)]
+        (set-gauge! impl metric)
+        (when push?
+          (flush-otel-metrics! otel)))))
   (push-metrics! [this]
     (when pushgateway
       (let [{:keys [client job registry grouping-keys]} pushgateway]

--- a/src/spootnik/reporter/specs.clj
+++ b/src/spootnik/reporter/specs.clj
@@ -23,6 +23,7 @@
 (s/def :spootnik.reporter.config/tls (s/nilable :spootnik.reporter.config/ssl-cert))
 (s/def :spootnik.reporter.config/endpoint (s/and string? #(str/starts-with? % "/")))
 (s/def :spootnik.reporter.config.otel/endpoint (s/and string? #(str/starts-with? % "http")))
+(s/def :spootnik.reporter.config.otel/initialize-sdk? boolean?)
 
 ;; riemann
 (s/def :spootnik.reporter.config.riemann/batch pos-int?)
@@ -38,6 +39,7 @@
 
 ;; pushgateway
 (s/def :spootnik.reporter.config.pushgateway/job keyword?)
+(s/def :spootnik.reporter.config.pushgateway/instance string?)
 (s/def :spootnik.reporter.config.pushgateway/name keyword?)
 (s/def :spootnik.reporter.config.pushgateway/type #{:gauge :counter})
 (s/def :spootnik.reporter.config.pushgateway/help string?)
@@ -57,9 +59,13 @@
 
 ;; otel
 (s/def :spootnik.reporter.config.metrics/otel (s/coll-of  :spootnik.reporter.config.pushgateway/metric))
-(s/def :spootnik.reporter.config.otel/otel (s/keys :req-un [:spootnik.reporter.config.otel/endpoint
-                                                            :spootnik.reporter.config.pushgateway/job]
-                                                   :opt-un [:spootnik.reporter.config.pushgateway/grouping-keys]))
+(s/def :spootnik.reporter.config.otel/otel (s/keys :req-un [:spootnik.reporter.config.otel/endpoint]
+                                                   :opt-un [:spootnik.reporter.config.pushgateway/grouping-keys
+                                                            :spootnik.reporter.config.pushgateway/job
+                                                            :spootnik.reporter.config.pushgateway/instance
+                                                            :spootnik.reporter.config.otel/initialize-sdk?]))
+
+
 
 ;; generic metrics reporter
 (s/def :spootnik.reporter.config.metrics.reporter.config/opts map?)

--- a/src/spootnik/reporter/specs.clj
+++ b/src/spootnik/reporter/specs.clj
@@ -22,6 +22,7 @@
 (s/def :spootnik.reporter.config/protocol string?)
 (s/def :spootnik.reporter.config/tls (s/nilable :spootnik.reporter.config/ssl-cert))
 (s/def :spootnik.reporter.config/endpoint (s/and string? #(str/starts-with? % "/")))
+(s/def :spootnik.reporter.config.otel/endpoint (s/and string? #(str/starts-with? % "http")))
 
 ;; riemann
 (s/def :spootnik.reporter.config.riemann/batch pos-int?)
@@ -54,6 +55,12 @@
                                                                           :spootnik.reporter.config.pushgateway/grouping-keys
                                                                           :spootnik.reporter.config/port]))
 
+;; otel
+(s/def :spootnik.reporter.config.metrics/otel (s/coll-of  :spootnik.reporter.config.pushgateway/metric))
+(s/def :spootnik.reporter.config.otel/otel (s/keys :req-un [:spootnik.reporter.config.otel/endpoint
+                                                            :spootnik.reporter.config.pushgateway/job]
+                                                   :opt-un [:spootnik.reporter.config.pushgateway/grouping-keys]))
+
 ;; generic metrics reporter
 (s/def :spootnik.reporter.config.metrics.reporter.config/opts map?)
 (s/def :spootnik.reporter.config.metrics.reporter.config/interval pos-int?)
@@ -75,7 +82,8 @@
                    :spootnik.reporter.config.metrics/riemann
                    :spootnik.reporter.config.metrics/console
                    :spootnik.reporter.config.metrics/jmx
-                   :spootnik.reporter.config.metrics/pushgateway]))
+                   :spootnik.reporter.config.metrics/pushgateway
+                   :spootnik.reporter.config.metrics/otel]))
 (s/def :spootnik.reporter.config/metrics
   (s/keys :req-un [:spootnik.reporter.config.metrics/reporters]))
 
@@ -99,4 +107,5 @@
                    :spootnik.reporter.config/metrics
                    :spootnik.reporter.config/riemann
                    :spootnik.reporter.config/prometheus
-                   :spootnik.reporter.config.pushgateway/pushgateway]))
+                   :spootnik.reporter.config.pushgateway/pushgateway
+                   :spootnik.reporter.config.otel/otel]))

--- a/test/spootnik/reporter/impl_test.clj
+++ b/test/spootnik/reporter/impl_test.clj
@@ -160,7 +160,20 @@
                            [:gauge :foo-gauge ["taba" "zar"] 3]
                            [:gauge :foo-gauge-b ["taba" "tec"] 4]
                            [:gauge :foo-gauge ["taba" "tec"] 5]
-                           [:counter :foo_counter ["taba" "tec"] 3]]]
+                           [:counter :foo_counter ["taba" "tec"] 3]]
+
+          expected   #{"foo_counter_total{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 4"
+                       "foo_counter_total{bar=\"taba\",baz=\"zar\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 1"
+                       "foo_gauge{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 5"
+                       "foo_gauge{bar=\"taba\",baz=\"zar\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 3"
+                       "foo_gauge_b{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 4"}
+
+          get-metrics (fn [url]
+                        (-> @(http/get url)
+                            :body
+                            bs/to-string
+                            clojure.string/split-lines
+                            set))]
 
       (doseq [metric metrics-to-push]
         (let [[type name label-values value] metric]
@@ -179,33 +192,12 @@
       (Thread/sleep 500)
 
       (testing "pushgateway metrics"
-        (let [pg-metrics (-> @(http/get "http://localhost:9091/metrics")
-                             :body
-                             bs/to-string
-                             clojure.string/split-lines
-                             set)
-              expected   #{"foo_counter_total{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 4"
-                           "foo_counter_total{bar=\"taba\",baz=\"zar\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 1"
-                           "foo_gauge{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 5"
-                           "foo_gauge{bar=\"taba\",baz=\"zar\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 3"
-                           "foo_gauge_b{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 4"}]
+        (let [pg-metrics (get-metrics "http://localhost:9091/metrics")]
           (is (cljset/subset? expected pg-metrics))))
 
       (testing "otel-collector metrics"
         ;; metrics have to go to otel first
-        (let [otel-metrics (-> @(http/get "http://localhost:9092/metrics")
-                               :body
-                               bs/to-string
-                               clojure.string/split-lines
-                               set)
-              expected   #{"foo_counter_total{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 4"
-                           "foo_counter_total{bar=\"taba\",baz=\"zar\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 1"
-                           "foo_gauge{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 5"
-                           "foo_gauge{bar=\"taba\",baz=\"zar\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 3"
-                           "foo_gauge_b{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 4"}]
-
+        (let [otel-metrics (get-metrics "http://localhost:9092/metrics")]
           (is (cljset/subset? expected otel-metrics))))
 
       (component/stop reporter))))
-
-;(metrics-send-events)

--- a/test/spootnik/reporter/impl_test.clj
+++ b/test/spootnik/reporter/impl_test.clj
@@ -8,8 +8,7 @@
             [spootnik.reporter.impl :as r :refer :all]
             [com.stuartsierra.component :as component]
             [spootnik.reporter.sentry :refer [http-requests-payload-stub]]
-            [clojure.set :as cljset]
-            [matcher-combinators.test :refer [match?]])
+            [clojure.set :as cljset])
   (:import io.prometheus.client.CollectorRegistry
            io.netty.handler.ssl.SslContextBuilder
            io.netty.handler.ssl.ClientAuth
@@ -177,6 +176,7 @@
                                 :label-values label-values}))))
       ;; push remaining metrics
       (push-metrics! reporter)
+      (Thread/sleep 500)
 
       (testing "pushgateway metrics"
         (let [pg-metrics (-> @(http/get "http://localhost:9091/metrics")
@@ -189,7 +189,7 @@
                            "foo_gauge{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 5"
                            "foo_gauge{bar=\"taba\",baz=\"zar\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 3"
                            "foo_gauge_b{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 4"}]
-          (is (match? expected pg-metrics))))
+          (is (cljset/subset? expected pg-metrics))))
 
       (testing "otel-collector metrics"
         ;; metrics have to go to otel first
@@ -204,12 +204,8 @@
                            "foo_gauge{bar=\"taba\",baz=\"zar\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 3"
                            "foo_gauge_b{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 4"}]
 
-          (is (match? expected otel-metrics))
-          (when-not (match? expected otel-metrics)
-            (println (cljset/difference expected otel-metrics))
-            (mapv println otel-metrics))))
-
+          (is (cljset/subset? expected otel-metrics))))
 
       (component/stop reporter))))
 
-(metrics-send-events)
+;(metrics-send-events)

--- a/test/spootnik/reporter/impl_test.clj
+++ b/test/spootnik/reporter/impl_test.clj
@@ -149,7 +149,8 @@
                                                                                      :otel        metrics}}
                                                            :otel        {:endpoint      "http://localhost:4317"
                                                                          :job           "testing"
-                                                                         :grouping-keys {:cluster "testing-cluster"}}
+                                                                         :grouping-keys {:cluster "testing-cluster"}
+                                                                         :initialize-sdk? true}
                                                            :pushgateway {:host          "localhost"
                                                                          :job           "testing"
                                                                          :grouping-keys {:cluster "testing-cluster"}

--- a/test/spootnik/reporter/impl_test.clj
+++ b/test/spootnik/reporter/impl_test.clj
@@ -5,14 +5,16 @@
             [clojure.string :as str]
             [clojure.test :refer :all]
             [prometheus.core :as prometheus]
-            [spootnik.reporter.impl :refer :all]
+            [spootnik.reporter.impl :as r :refer :all]
             [com.stuartsierra.component :as component]
             [spootnik.reporter.sentry :refer [http-requests-payload-stub]]
-            [clojure.set :as cljset])
+            [clojure.set :as cljset]
+            [matcher-combinators.test :refer [match?]])
   (:import io.prometheus.client.CollectorRegistry
            io.netty.handler.ssl.SslContextBuilder
            io.netty.handler.ssl.ClientAuth
-           java.lang.String))
+           java.lang.String
+           [io.opentelemetry.api GlobalOpenTelemetry]))
 
 (deftest timers-do-not-modify-the-world
   (let [reporter (component/start (map->Reporter {:metrics {:reporters {:console {:interval 100}}}}))]
@@ -55,11 +57,11 @@
         store    (:prometheus reporter)
         _        (prometheus/init-defaults)
         store    (prometheus/register-counter
-                  store
-                  "test"
-                  "native_counter"
-                  "do you even increment?"
-                  ["test"])]
+                   store
+                   "test"
+                   "native_counter"
+                   "do you even increment?"
+                   ["test"])]
     (prometheus/increase-counter store "test" "native_counter" ["test"] 42)
     (let [metrics (prometheus-str-metrics)]
       (testing "store a native prometheus metric in the registry"
@@ -92,17 +94,17 @@
       (is (= 200
              (:status @(http/get (format "https://localhost:%s/metrics" port)
                                  {:pool (http/connection-pool
-                                         {:connection-options
-                                          {:ssl-context client-context}})})))))
+                                          {:connection-options
+                                           {:ssl-context client-context}})})))))
     (testing "with tls configured, a request without valid certs should fail"
       (is (thrown?
-           clojure.lang.ExceptionInfo
-           @(http/get (format "https://localhost:%s/metrics" port)))))
+            clojure.lang.ExceptionInfo
+            @(http/get (format "https://localhost:%s/metrics" port)))))
     (component/stop reporter)))
 
 (deftest prometheus-metrics-endpoint
   (let [port       sample-port
-        prometheus {:prometheus {:port port
+        prometheus {:prometheus {:port     port
                                  :endpoint "/metrics"}
                     :metrics    {:reporters {:prometheus {}}}}
         system     (map->Reporter prometheus)
@@ -112,13 +114,13 @@
              (:status @(http/get (format "http://localhost:%s/metrics" port))))))
     (testing "requests to non-specified endpoint return 404"
       (is (thrown?
-           clojure.lang.ExceptionInfo
-           @(http/get (format "http://localhost:%s/nothing" port)))))
+            clojure.lang.ExceptionInfo
+            @(http/get (format "http://localhost:%s/nothing" port)))))
     (component/stop reporter)))
 
 (deftest sentry-sends-events
   (testing "we can send events to sentry using the :memory: backend"
-    (let [reporter (component/start (map->Reporter {:sentry {:dsn ":memory:"}
+    (let [reporter (component/start (map->Reporter {:sentry  {:dsn ":memory:"}
                                                     :metrics {:reporters {:console {:interval 100}}}}))]
 
       (.capture! ^spootnik.reporter.impl.SentrySink reporter {:message "A simple test event"})
@@ -126,60 +128,88 @@
 
       (component/stop reporter))))
 
-(deftest pushgateway-send-events
+(deftest metrics-send-events
+  (GlobalOpenTelemetry/resetForTest)
   (testing "Sending events to pushgateway"
-    (let [reporter (component/start (map->Reporter {:metrics {:reporters {:pushgateway  [{:name
-                                                                                          :foo_counter
-                                                                                          :help "A Counter"
-                                                                                          :type :counter
-                                                                                          :label-names [:bar :baz]}
-                                                                                         {:name
-                                                                                          :foo-gauge
-                                                                                          :help "A Gauge"
-                                                                                          :type :gauge
-                                                                                          :label-names [:bar :baz]}
-                                                                                         {:name
-                                                                                          :foo-gauge-b
-                                                                                          :help "YAG"
-                                                                                          :type :gauge
-                                                                                          :label-names [:bar :baz]}]}}
-                                                    :pushgateway {:host "localhost"
-                                                                  :job "testing"
-                                                                  :grouping-keys {:cluster "testing-cluster"}
-                                                                  :port 9091}}))
-          metrics-to-push [[:counter :foo_counter  ["taba" "tec"] 0]
-                           [:counter :foo_counter  ["taba" "zar"] 0]
-                           [:gauge   :foo-gauge    ["taba" "tec"] 2]
-                           [:gauge   :foo-gauge    ["taba" "zar"] 3]
-                           [:gauge   :foo-gauge-b  ["taba" "tec"] 4]
-                           [:gauge   :foo-gauge    ["taba" "tec"] 5]
-                           [:counter :foo_counter  ["taba" "tec"] 3]]]
+    (let [metrics         [{:name
+                            :foo_counter
+                            :help        "A Counter"
+                            :type        :counter
+                            :label-names [:bar :baz]}
+                           {:name
+                            :foo-gauge
+                            :help        "A Gauge"
+                            :type        :gauge
+                            :label-names [:bar :baz]}
+                           {:name
+                            :foo-gauge-b
+                            :help        "YAG"
+                            :type        :gauge
+                            :label-names [:bar :baz]}]
+          reporter        (component/start (map->Reporter {:metrics     {:reporters {:pushgateway metrics
+                                                                                     :otel        metrics}}
+                                                           :otel        {:endpoint      "http://localhost:4317"
+                                                                         :job           "testing"
+                                                                         :grouping-keys {:cluster "testing-cluster"}}
+                                                           :pushgateway {:host          "localhost"
+                                                                         :job           "testing"
+                                                                         :grouping-keys {:cluster "testing-cluster"}
+                                                                         :port          9091}}))
+          metrics-to-push [[:counter :foo_counter ["taba" "tec"] 0]
+                           [:counter :foo_counter ["taba" "zar"] 0]
+                           [:gauge :foo-gauge ["taba" "tec"] 2]
+                           [:gauge :foo-gauge ["taba" "zar"] 3]
+                           [:gauge :foo-gauge-b ["taba" "tec"] 4]
+                           [:gauge :foo-gauge ["taba" "tec"] 5]
+                           [:counter :foo_counter ["taba" "tec"] 3]]]
 
       (doseq [metric metrics-to-push]
         (let [[type name label-values value] metric]
           (condp = type
             :counter
-            (.counter! ^spootnik.reporter.impl.PushGatewaySink reporter (cond-> {:name         name
-                                                                                 :label-values label-values
-                                                                                 :push? false}
-                                                                          (not= 0 value) (assoc :value value)))
+            (r/counter! reporter (cond-> {:name         name
+                                          :label-values label-values
+                                          :push?        false}
+                                         (not= 0 value) (assoc :value value)))
             :gauge
-            (.gauge! ^spootnik.reporter.impl.PushGatewaySink reporter {:name name
-                                                                       :value value
-                                                                       :label-values label-values}))))
+            (r/gauge! reporter {:name         name
+                                :value        value
+                                :label-values label-values}))))
       ;; push remaining metrics
       (push-metrics! reporter)
 
-      (let [pg-metrics (-> @(http/get "http://localhost:9091/metrics")
-                           :body
-                           bs/to-string
-                           clojure.string/split-lines
-                           set)
-            expected   #{"foo_counter_total{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 4"
-                         "foo_counter_total{bar=\"taba\",baz=\"zar\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 1"
-                         "foo_gauge{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 5"
-                         "foo_gauge{bar=\"taba\",baz=\"zar\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 3"
-                         "foo_gauge_b{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 4"}]
-        (is (true? (cljset/subset? expected pg-metrics))))
+      (testing "pushgateway metrics"
+        (let [pg-metrics (-> @(http/get "http://localhost:9091/metrics")
+                             :body
+                             bs/to-string
+                             clojure.string/split-lines
+                             set)
+              expected   #{"foo_counter_total{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 4"
+                           "foo_counter_total{bar=\"taba\",baz=\"zar\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 1"
+                           "foo_gauge{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 5"
+                           "foo_gauge{bar=\"taba\",baz=\"zar\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 3"
+                           "foo_gauge_b{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 4"}]
+          (is (match? expected pg-metrics))))
+
+      (testing "otel-collector metrics"
+        ;; metrics have to go to otel first
+        (let [otel-metrics (-> @(http/get "http://localhost:9092/metrics")
+                               :body
+                               bs/to-string
+                               clojure.string/split-lines
+                               set)
+              expected   #{"foo_counter_total{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 4"
+                           "foo_counter_total{bar=\"taba\",baz=\"zar\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 1"
+                           "foo_gauge{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 5"
+                           "foo_gauge{bar=\"taba\",baz=\"zar\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 3"
+                           "foo_gauge_b{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 4"}]
+
+          (is (match? expected otel-metrics))
+          (when-not (match? expected otel-metrics)
+            (println (cljset/difference expected otel-metrics))
+            (mapv println otel-metrics))))
+
 
       (component/stop reporter))))
+
+(metrics-send-events)

--- a/test/spootnik/reporter/specs_test.clj
+++ b/test/spootnik/reporter/specs_test.clj
@@ -4,35 +4,36 @@
             [spootnik.reporter.specs]))
 
 (def valid-reporter-config
-  {:sentry {:dsn "https://dummy:dsn@errors.sentry-host.com/31337"}
-   :prometheus {:port 8007}
-   :pushgateway {:host "localhost"
-                 :job :foo
-                 :port 9091
+  {:sentry      {:dsn "https://dummy:dsn@errors.sentry-host.com/31337"}
+   :prometheus  {:port 8007}
+   :pushgateway {:host          "localhost"
+                 :job           :foo
+                 :port          9091
                  :grouping-keys {:cache "hit"}}
 
-   :otel        {:endpoint      "http://localhost:4317"
-                 :job           :testing
-                 :grouping-keys {:cluster "testing-cluster"}}
-   :riemann {:host     "riemann.svc"
-             :port     5554
-             :protocol "tls"
+   :otel        {:endpoint        "http://localhost:4317"
+                 :job             :testing
+                 :grouping-keys   {:cluster "testing-cluster"}
+                 :initialize-sdk? true}
+   :riemann     {:host     "riemann.svc"
+                 :port     5554
+                 :protocol "tls"
 
-             :defaults {:ttl  600
-                        :host "localhost"
-                        :tags ["cpu" "graph"]}
+                 :defaults {:ttl  600
+                            :host "localhost"
+                            :tags ["cpu" "graph"]}
 
-             :tls {:cert      "/etc/riemann/ssl/cert.pem"
-                   :ca-cert   "/etc/riemann/ssl/ca.pem"
-                   :pkey      "/etc/riemann/ssl/key.pkcs8"}}
-   :metrics {:reporters {:riemann {:interval 10
-                                   :opts     {:ttl       20
-                                              :tags      ["cpu" "graph"]
-                                              :host-name "localhost"}}
-                         :pushgateway  [{:name :foo-bar
-                                         :type :gauge
-                                         :help "Lorem Ipsum"
-                                         :label-names [:foo :bar]}]}}})
+                 :tls      {:cert    "/etc/riemann/ssl/cert.pem"
+                            :ca-cert "/etc/riemann/ssl/ca.pem"
+                            :pkey    "/etc/riemann/ssl/key.pkcs8"}}
+   :metrics     {:reporters {:riemann     {:interval 10
+                                           :opts     {:ttl       20
+                                                      :tags      ["cpu" "graph"]
+                                                      :host-name "localhost"}}
+                             :pushgateway [{:name        :foo-bar
+                                            :type        :gauge
+                                            :help        "Lorem Ipsum"
+                                            :label-names [:foo :bar]}]}}})
 
 (deftest reporter-spec-validates-correctly-test
   (testing "A correct spec should be valid"

--- a/test/spootnik/reporter/specs_test.clj
+++ b/test/spootnik/reporter/specs_test.clj
@@ -10,6 +10,10 @@
                  :job :foo
                  :port 9091
                  :grouping-keys {:cache "hit"}}
+
+   :otel        {:endpoint      "http://localhost:4317"
+                 :job           :testing
+                 :grouping-keys {:cluster "testing-cluster"}}
    :riemann {:host     "riemann.svc"
              :port     5554
              :protocol "tls"


### PR DESCRIPTION
Otel collector requires the following config:
- `send_timestamps: false` so that the metrics don't have the timestamp at the end
- `add_metric_suffixes: true` to ensure eg :`_total` metrics are created

```
exporters:

  prometheus:
    ...
    send_timestamps: false
    add_metric_suffixes: true
```

[sc-111534]