### PR TITLE
pushgateway: allow arbitrary path-prefix to be set

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -8,6 +8,11 @@ jobs:
         image: prom/pushgateway
         ports:
         - 9091:9091/tcp
+      pushgateway-with-path-prefix:
+        image: prom/pushgateway
+        ports:
+          - 19091:9091/tcp
+        command: --web.external-url "/path/prefix"
     steps:
     - uses: actions/checkout@v6
     - name: Install clojure tools

--- a/src/spootnik/reporter/impl.clj
+++ b/src/spootnik/reporter/impl.clj
@@ -338,10 +338,11 @@
   (.register collector registry))
 
 (defn build-pushgateway-client
-  [{:keys [host port tls]
-    :or {port 9091}}]
+  [{:keys [host port tls path-prefix]
+    :or {port 9091
+         path-prefix ""}}]
   (let [protocol (if tls "https" "http")
-        url (URL. protocol host port "")
+        url (URL. protocol host port path-prefix)
         client (PushGateway. url)]
     (when tls
       (.setConnectionFactory client (https-connection-factory tls)))

--- a/src/spootnik/reporter/specs.clj
+++ b/src/spootnik/reporter/specs.clj
@@ -21,6 +21,7 @@
 (s/def :spootnik.reporter.config/host string?)
 (s/def :spootnik.reporter.config/protocol string?)
 (s/def :spootnik.reporter.config/tls (s/nilable :spootnik.reporter.config/ssl-cert))
+(s/def :spootnik.reporter.config/path-prefix (s/and string? #(str/starts-with? % "/")))
 (s/def :spootnik.reporter.config/endpoint (s/and string? #(str/starts-with? % "/")))
 
 ;; riemann
@@ -52,7 +53,8 @@
                                                                           :spootnik.reporter.config.pushgateway/job]
                                                                  :opt-un [:spootnik.reporter.config/tls
                                                                           :spootnik.reporter.config.pushgateway/grouping-keys
-                                                                          :spootnik.reporter.config/port]))
+                                                                          :spootnik.reporter.config/port
+                                                                          :spootnik.reporter.config/path-prefix]))
 
 ;; generic metrics reporter
 (s/def :spootnik.reporter.config.metrics.reporter.config/opts map?)

--- a/test/spootnik/reporter/impl_test.clj
+++ b/test/spootnik/reporter/impl_test.clj
@@ -181,4 +181,62 @@
                          "foo_gauge_b{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 4"}]
         (is (true? (cljset/subset? expected pg-metrics))))
 
+      (component/stop reporter)))
+
+  (testing "Sending events to pushgateway with prefix"
+    (let [reporter (component/start (map->Reporter {:metrics {:reporters {:pushgateway  [{:name
+                                                                                          :foo_counter
+                                                                                          :help "A Counter"
+                                                                                          :type :counter
+                                                                                          :label-names [:bar :baz]}
+                                                                                         {:name
+                                                                                          :foo-gauge
+                                                                                          :help "A Gauge"
+                                                                                          :type :gauge
+                                                                                          :label-names [:bar :baz]}
+                                                                                         {:name
+                                                                                          :foo-gauge-b
+                                                                                          :help "YAG"
+                                                                                          :type :gauge
+                                                                                          :label-names [:bar :baz]}]}}
+                                                    :pushgateway {:host "localhost"
+                                                                  :path-prefix "/path/prefix"
+                                                                  :job "testing"
+                                                                  :grouping-keys {:cluster "testing-cluster"}
+                                                                  :port 19091}}))
+          metrics-to-push [[:counter :foo_counter  ["taba" "tec"] 0]
+                           [:counter :foo_counter  ["taba" "zar"] 0]
+                           [:gauge   :foo-gauge    ["taba" "tec"] 2]
+                           [:gauge   :foo-gauge    ["taba" "zar"] 3]
+                           [:gauge   :foo-gauge-b  ["taba" "tec"] 4]
+                           [:gauge   :foo-gauge    ["taba" "tec"] 5]
+                           [:counter :foo_counter  ["taba" "tec"] 3]]]
+
+      (doseq [metric metrics-to-push]
+        (let [[type name label-values value] metric]
+          (condp = type
+            :counter
+            (.counter! ^spootnik.reporter.impl.PushGatewaySink reporter (cond-> {:name name
+                                                                                 :label-values label-values
+                                                                                 :push? false}
+                                                                          (not= 0 value) (assoc :value value)))
+            :gauge
+            (.gauge! ^spootnik.reporter.impl.PushGatewaySink reporter {:name name
+                                                                       :value value
+                                                                       :label-values label-values}))))
+      ;; push remaining metrics
+      (push-metrics! reporter)
+
+      (let [pg-metrics (-> @(http/get "http://localhost:19091/path/prefix/metrics")
+                           :body
+                           bs/to-string
+                           clojure.string/split-lines
+                           set)
+            expected   #{"foo_counter_total{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 4"
+                         "foo_counter_total{bar=\"taba\",baz=\"zar\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 1"
+                         "foo_gauge{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 5"
+                         "foo_gauge{bar=\"taba\",baz=\"zar\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 3"
+                         "foo_gauge_b{bar=\"taba\",baz=\"tec\",cluster=\"testing-cluster\",instance=\"\",job=\"testing\"} 4"}]
+        (is (true? (cljset/subset? expected pg-metrics))))
+
       (component/stop reporter))))

--- a/test/spootnik/reporter/impl_test.clj
+++ b/test/spootnik/reporter/impl_test.clj
@@ -3,15 +3,14 @@
             [byte-streams :as bs]
             [clojure.java.io :as io]
             [clojure.string :as str]
-            [clojure.test :refer :all]
+            [clojure.test :refer [deftest is testing]]
             [prometheus.core :as prometheus]
-            [spootnik.reporter.impl :refer :all]
+            [spootnik.reporter.impl :refer [map->Reporter prometheus-str-metrics push-metrics! time!]]
             [com.stuartsierra.component :as component]
             [spootnik.reporter.sentry :refer [http-requests-payload-stub]]
             [clojure.set :as cljset])
   (:import io.prometheus.client.CollectorRegistry
            io.netty.handler.ssl.SslContextBuilder
-           io.netty.handler.ssl.ClientAuth
            java.lang.String))
 
 (deftest timers-do-not-modify-the-world

--- a/test/spootnik/reporter/impl_test.clj
+++ b/test/spootnik/reporter/impl_test.clj
@@ -183,7 +183,7 @@
 
       (component/stop reporter)))
 
-  (testing "Sending events to pushgateway with prefix"
+  (testing "Sending events to pushgateway with a path-prefix"
     (let [reporter (component/start (map->Reporter {:metrics {:reporters {:pushgateway  [{:name
                                                                                           :foo_counter
                                                                                           :help "A Counter"

--- a/test/spootnik/reporter/specs_test.clj
+++ b/test/spootnik/reporter/specs_test.clj
@@ -50,4 +50,7 @@
     (is (some? (s/explain-data :spootnik.reporter/config (assoc-in valid-reporter-config [:pushgateway :host] nil)))))
 
   (testing "PushGateway path-prefix should not be empty"
-    (is (some? (s/explain-data :spootnik.reporter/config (assoc-in valid-reporter-config [:pushgateway :path-prefix] nil))))))
+    (is (some? (s/explain-data :spootnik.reporter/config (assoc-in valid-reporter-config [:pushgateway :path-prefix] nil)))))
+
+  (testing "PushGateway path-prefix is optional"
+    (is (not (s/explain-data :spootnik.reporter/config (update-in valid-reporter-config [:pushgateway] dissoc :path-prefix))))))

--- a/test/spootnik/reporter/specs_test.clj
+++ b/test/spootnik/reporter/specs_test.clj
@@ -1,13 +1,15 @@
 (ns spootnik.reporter.specs-test
-  (:require [clojure.test :refer :all]
-            [clojure.spec.alpha :as s]
-            [spootnik.reporter.specs]))
+  (:require
+   [clojure.spec.alpha :as s]
+   [clojure.test :refer [deftest is testing]]
+   [spootnik.reporter.specs]))
 
 (def valid-reporter-config
   {:sentry {:dsn "https://dummy:dsn@errors.sentry-host.com/31337"}
    :prometheus {:port 8007}
    :pushgateway {:host "localhost"
                  :job :foo
+                 :path-prefix "/path/prefix"
                  :port 9091
                  :grouping-keys {:cache "hit"}}
    :riemann {:host     "riemann.svc"
@@ -45,4 +47,7 @@
     (is (some? (s/explain-data :spootnik.reporter/config (assoc-in valid-reporter-config [:riemann :host] nil)))))
 
   (testing "PushGateway host should not be empty"
-    (is (some? (s/explain-data :spootnik.reporter/config (assoc-in valid-reporter-config [:pushgateway :host] nil))))))
+    (is (some? (s/explain-data :spootnik.reporter/config (assoc-in valid-reporter-config [:pushgateway :host] nil)))))
+
+  (testing "PushGateway path-prefix should not be empty"
+    (is (some? (s/explain-data :spootnik.reporter/config (assoc-in valid-reporter-config [:pushgateway :path-prefix] nil))))))


### PR DESCRIPTION
Allowing a path-prefix in the _pushgateway client_ would allow to use the reporter to send metrics to a third party metric system like [Victoria Metrics](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#how-to-import-data-in-prometheus-exposition-format).